### PR TITLE
Better pip caching when building images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN chmod 777 /tmp/install_talib.sh
 RUN cd /tmp && /tmp/install_talib.sh && rm -r /tmp/*ta-lib*
 ENV LD_LIBRARY_PATH /usr/local/lib
 
-COPY . .
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
+COPY . .
 
 ENTRYPOINT ["python"]
 CMD ["main.py"]


### PR DESCRIPTION
After this change docker will only reinstall dependencies from `requirements.txt` whenever this file is changed. Before, it would run it every time, which results in extra build time