### PR TITLE
cleanup calculation

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1,7 +1,7 @@
 from tabulate import tabulate
 from datetime import datetime, timedelta
-from collections import defaultdict, namedtuple
 from backtesting.results import MainResults, OpenTradeResult, CoinInsights, show_signature
+import utils
 
 import typing
 from tqdm import tqdm
@@ -98,11 +98,9 @@ class BackTesting:
 
     def generate_main_results(self, open_trades: [Trade], closed_trades: [Trade], budget: float) -> MainResults:
         
-        budget += self.calculate_worth_of_open_trades(open_trades)
-        # starting_capital = self.starting_capital
+        budget += utils.calculate_worth_of_open_trades(open_trades)
         overall_profit = ((budget - self.starting_capital) / self.starting_capital) * 100
         max_seen_drawdown = self.calculate_max_seen_drawdown()
-        # loss = self.calculate_loss_trades(closed_trades)
 
         return MainResults(tested_from=datetime.fromtimestamp(self.backtesting_from / 1000),
                            tested_to=datetime.fromtimestamp(self.backtesting_to / 1000),
@@ -123,28 +121,18 @@ class BackTesting:
         stats = self.calculate_statistics_per_coin(open_trades, closed_trades)
         new_stats = []
         for coin in stats:
-            sell_reasons = {
-                "ROI": 0,
-                "Stoploss": 0,
-                "Sell signal": 0
-            }
             durations = list(stats[coin]['avg_duration'])
             average_timedelta = sum(durations, timedelta(0)) / len(durations)
-            stats[coin]['total_profit_prct'] = (
-                stats[coin]['total_profit_prct'] / stats[coin]['amount_of_trades'])
-            for reason in stats[coin]['sell_reasons']:
-                if reason is not None:
-                    sell_reasons[reason] += stats[coin]['sell_reasons'][reason]
-
+            avg_profit_prct = (stats[coin]['total_profit_prct'] / stats[coin]['amount_of_trades'])
             coin_insight = CoinInsights(pair=coin,
-                                           avg_profit_percentage=stats[coin]['total_profit_prct'],
+                                           avg_profit_percentage=avg_profit_prct,
                                            profit=stats[coin]['total_profit_amount'],
                                            n_trades=stats[coin]['amount_of_trades'],
                                            max_drawdown=stats[coin]['max_drawdown'],
                                            avg_duration=average_timedelta,
-                                           roi=sell_reasons['ROI'],
-                                           stoploss=sell_reasons['Stoploss'],
-                                           sell_signal=sell_reasons['Sell signal'])
+                                           roi=stats[coin]['sell_reasons']['ROI'],
+                                           stoploss=stats[coin]['sell_reasons']['Stoploss'],
+                                           sell_signal=stats[coin]['sell_reasons']['Sell signal'])
             new_stats.append(coin_insight)
 
         return new_stats
@@ -164,22 +152,6 @@ class BackTesting:
 
             open_trade_stats.append(open_trade_res)
         return open_trade_stats
-
-
-    # Helper method for calculating worth of open trades
-    def calculate_worth_of_open_trades(self, open_trades: [Trade]) -> float:
-        """
-        Method calculates worth of open trades
-
-        :param open_trades: array of open trades
-        :type open_trades: [Trade]
-        :return: returns the total value of all open trades
-        :rtype: float
-        """
-        return_value = 0
-        for trade in open_trades:
-            return_value += (trade.currency_amount * trade.current)
-        return return_value
 
     def calculate_statistics_per_coin(self, open_trades, closed_trades):
         """
@@ -201,7 +173,7 @@ class BackTesting:
                 'amount_of_trades' : 0,
                 'max_drawdown' : 0.0,
                 'avg_duration' : [],
-                'sell_reasons' : defaultdict(int)
+                'sell_reasons' : utils.default_empty_dict_dict()
             } for pair in self.data.keys()
         }
 
@@ -220,8 +192,7 @@ class BackTesting:
                 trades_per_coin[trade.pair]['avg_duration'].append(trade.closed_at - trade.opened_at)
                 trades_per_coin[trade.pair]['sell_reasons'][trade.sell_reason] += 1
             else:
-                trades_per_coin[trade.pair]['avg_duration'].append(
-                    datetime.now() - trade.opened_at)
+                trades_per_coin[trade.pair]['avg_duration'].append(datetime.now() - trade.opened_at)
 
         return trades_per_coin
 
@@ -284,14 +255,3 @@ class BackTesting:
                 loss_trades += 1
         return loss_trades
 
-    def default_empty_array_dict(self) -> list:
-        """
-        Helper method for initializing defaultdict containing arrays
-        """
-        return []
-
-    def default_empty_dict_dict(self) -> dict:
-        """
-        Helper method for initializing defaultdict
-        """
-        return defaultdict()

--- a/data/tradingmodule.py
+++ b/data/tradingmodule.py
@@ -3,6 +3,7 @@ from backtesting.strategy import Strategy
 from models.trade import Trade
 from datetime import datetime
 from pandas import DataFrame, Series
+import utils
 
 
 # ======================================================================
@@ -181,17 +182,6 @@ class TradingModule:
                 return trade
         return None
 
-    def get_total_value_of_open_trades(self) -> float:
-        """
-        Method calculates the total value of all open trades
-        :return: The total value in base-currency of all open trades
-        :rtype: float
-        """
-        return_value = 0
-        for trade in self.open_trades:
-            return_value += (trade.currency_amount * trade.current)
-        return return_value
-
     def update_value_per_timestamp_tracking(self, trade: Trade, ohlcv: Series) -> None:
         """
         Method is used to be able to track the value change per timestamp per open trade
@@ -232,7 +222,7 @@ class TradingModule:
         if trade.profit_percentage < self.max_drawdown:
             self.max_drawdown = trade.profit_percentage
 
-        current_total_value = self.budget + self.get_total_value_of_open_trades()
+        current_total_value = self.budget + utils.calculate_worth_of_open_trades(self.open_trades)
         perc_of_total_value = ((trade.currency_amount * trade.close) / current_total_value) * 100
         perc_influence = trade.profit_percentage * (perc_of_total_value / 100)
 

--- a/utils.py
+++ b/utils.py
@@ -7,15 +7,12 @@ def get_project_root():
 
 
 def default_empty_array_dict() -> list:
-    """ :return: list for initializing dictionary :rtype: List """
+    """:return: list for initializing dictionary :rtype: List"""
     return []
 
 
 def default_empty_dict_dict() -> dict:
-    """
-    :return: Dictionary for initializing default dictionary
-    :rtype: Dict
-    """
+    """:return: Dictionary for initializing default dictionary :rtype: Dict"""
     return defaultdict(int)
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 from collections import defaultdict
 
+
 def get_project_root():
     return Path(__file__).parent
 
+
 def default_empty_array_dict() -> list:
-    """
-    :return: list for initializing dictionary
-    :rtype: List
-    """
+    """ :return: list for initializing dictionary :rtype: List """
     return []
+
 
 def default_empty_dict_dict() -> dict:
     """
@@ -17,6 +17,7 @@ def default_empty_dict_dict() -> dict:
     :rtype: Dict
     """
     return defaultdict(int)
+
 
 def calculate_worth_of_open_trades(open_trades) -> float:
     """

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,31 @@
 from pathlib import Path
+from collections import defaultdict, namedtuple
 
 def get_project_root():
     return Path(__file__).parent
+
+def default_empty_array_dict() -> list:
+    """
+    Helper method for initializing defaultdict containing arrays
+    """
+    return []
+
+def default_empty_dict_dict() -> dict:
+    """
+    Helper method for initializing defaultdict
+    """
+    return defaultdict(int)
+
+def calculate_worth_of_open_trades(open_trades) -> float:
+    """
+    Method calculates worth of open trades
+
+    :param open_trades: array of open trades
+    :type open_trades: [Trade]
+    :return: returns the total value of all open trades
+    :rtype: float
+    """
+    return_value = 0
+    for trade in open_trades:
+        return_value += (trade.currency_amount * trade.current)
+    return return_value

--- a/utils.py
+++ b/utils.py
@@ -7,23 +7,21 @@ def get_project_root():
 
 
 def default_empty_array_dict() -> list:
-    """:return: list for initializing dictionary :rtype: List"""
+    """:return: list for initializing dictionary :rtype: List."""
     return []
 
 
 def default_empty_dict_dict() -> dict:
-    """:return: Dictionary for initializing default dictionary :rtype: Dict"""
+    """:return: Dictionary for initializing default dictionary :rtype: Dict."""
     return defaultdict(int)
 
 
 def calculate_worth_of_open_trades(open_trades) -> float:
-    """
-    Method calculates worth of open trades
-
+    """Method calculates worth of open trades
     :param open_trades: array of open trades
     :type open_trades: [Trade]
     :return: returns the total value of all open trades
-    :rtype: float
+    :rtype: float.
     """
     return_value = 0
     for trade in open_trades:

--- a/utils.py
+++ b/utils.py
@@ -5,11 +5,17 @@ def get_project_root():
     return Path(__file__).parent
 
 def default_empty_array_dict() -> list:
-    """ Helper method for initializing defaultdict containing arrays """
+    """
+    :return: list for initializing dictionary
+    :rtype: List
+    """
     return []
 
 def default_empty_dict_dict() -> dict:
-    """ Helper method for initializing defaultdict """
+    """
+    :return: Dictionary for initializing default dictionary
+    :rtype: Dict
+    """
     return defaultdict(int)
 
 def calculate_worth_of_open_trades(open_trades) -> float:

--- a/utils.py
+++ b/utils.py
@@ -7,18 +7,24 @@ def get_project_root():
 
 
 def default_empty_array_dict() -> list:
-    """:return: list for initializing dictionary :rtype: List."""
+    """
+    :return: list for initializing dictionary
+    :rtype: List.
+    """
     return []
 
 
 def default_empty_dict_dict() -> dict:
-    """:return: Dictionary for initializing default dictionary :rtype: Dict."""
+    """
+    :return: Dictionary for initializing default dictionary
+    :rtype: Dict.
+    """
     return defaultdict(int)
 
 
 def calculate_worth_of_open_trades(open_trades) -> float:
-    """Method calculates worth of open trades
-    
+    """
+    Method calculates worth of open trades
     :param open_trades: array of open trades
     :type open_trades: [Trade]
     :return: returns the total value of all open trades

--- a/utils.py
+++ b/utils.py
@@ -1,19 +1,15 @@
 from pathlib import Path
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 
 def get_project_root():
     return Path(__file__).parent
 
 def default_empty_array_dict() -> list:
-    """
-    Helper method for initializing defaultdict containing arrays
-    """
+    """ Helper method for initializing defaultdict containing arrays """
     return []
 
 def default_empty_dict_dict() -> dict:
-    """
-    Helper method for initializing defaultdict
-    """
+    """ Helper method for initializing defaultdict """
     return defaultdict(int)
 
 def calculate_worth_of_open_trades(open_trades) -> float:

--- a/utils.py
+++ b/utils.py
@@ -25,3 +25,4 @@ def calculate_worth_of_open_trades(open_trades) -> float:
     for trade in open_trades:
         return_value += (trade.currency_amount * trade.current)
     return return_value
+

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ def default_empty_dict_dict() -> dict:
 
 def calculate_worth_of_open_trades(open_trades) -> float:
     """Method calculates worth of open trades
+    
     :param open_trades: array of open trades
     :type open_trades: [Trade]
     :return: returns the total value of all open trades


### PR DESCRIPTION
# Fixes
Fixes #48


# What has been changed?
Checked calculation; ran and recalculated everything
Removed redundant sell reasons dict (from generate coin result)
renamed var for avg_profit_prct
moved helper functions to utils

# Examples
As it was, the sell seasons dict was first calculated and then recalculated in exacly the same format.

# Actions to be performed before this can be merged
None

# Security Measures
n/a