### PR TITLE
Adding a check for missing ticks

### DIFF
--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -1,6 +1,5 @@
 # Libraries
 import numpy as np
-from datetime import datetime, timedelta
 from pandas import DataFrame
 import pandas as pd
 import ccxt

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -361,9 +361,10 @@ class DataModule:
             diff = np.setdiff1d(daterange, index)
             n_missing = len(diff)
 
-            if n_nan > 0 or n_missing > 0:
-                print(f"[WARNING] Pair '{pair}' contains {n_nan} rows with NaN values\n"
-                      f"[WARNING] and {n_missing} missing ticks")
+            if n_nan > 0:
+                print(f"[WARNING] Pair '{pair}' contains {n_nan} rows with NaN values")
+            if n_missing > 0:
+                print(f"[WARNING] Pair '{pair}' is missing {n_missing} ticks (rows)")
 
             
 

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -366,7 +366,7 @@ class DataModule:
             n_missing = len(diff)
 
             if n_nan > 0 or n_missing > 0:
-                print(f"[WARNING] Pair '{pair}' contains {n_nan} rows with Nan values\n"
+                print(f"[WARNING] Pair '{pair}' contains {n_nan} rows with NaN values\n"
                       f"[WARNING] and {n_missing} missing ticks")
 
             

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -93,6 +93,8 @@ class DataModule:
                 df = self.read_data_from_datafile(pair)
             self.history_data[pair] = df
 
+        self.check_for_missing_ticks()
+
         if self.same_backtesting_period():
             self.backtesting_module.start_backtesting(self.history_data, self.backtesting_from, self.backtesting_to)
         else:
@@ -341,3 +343,10 @@ class DataModule:
         filename = self.generate_datafile_name(pair)
         filepath = os.path.join("data/backtesting-data/", self.config["exchange"], filename)
         os.remove(filepath)
+
+    def check_for_missing_ticks(self):
+        for pair, data in self.history_data.items():
+            n_missing = data.isnull().any(axis="columns").sum()
+            if n_missing > 0:
+                print(f"[WARNING] Pair '{pair}' contains {n_missing} missing ticks")
+        

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -1,4 +1,5 @@
 import numpy as np
+from datetime import datetime, timedelta
 from pandas import DataFrame
 import pandas as pd
 import ccxt
@@ -345,8 +346,30 @@ class DataModule:
         os.remove(filepath)
 
     def check_for_missing_ticks(self):
+        """Test whether any tick has a null/NaN value, and whether every
+        tick (time) exists"""
+
+        # all the dates that the data should have, times one million
+        # because of the date conventions of pandas
+        daterange = np.arange(self.backtesting_from * 1000000,
+                              self.backtesting_to * 1000000,
+                              self.timeframe_calc * 1000000)
+
         for pair, data in self.history_data.items():
-            n_missing = data.isnull().any(axis="columns").sum()
-            if n_missing > 0:
-                print(f"[WARNING] Pair '{pair}' contains {n_missing} missing ticks")
+
+            # any NaN?
+            n_nan = data.isnull().any(axis="columns").sum()
+            
+            # missing dates?
+            index = data.index.to_numpy().astype(int)
+            diff = np.setdiff1d(daterange, index)
+            n_missing = len(diff)
+
+            if n_nan > 0 or n_missing > 0:
+                print(f"[WARNING] Pair '{pair}' contains {n_nan} rows with Nan values\n"
+                      f"[WARNING] and {n_missing} missing ticks")
+
+            
+
+
         

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -347,11 +347,9 @@ class DataModule:
         """Test whether any tick has a null/NaN value, and whether every
         tick (time) exists"""
 
-        # all the dates that the data should have, times one million
-        # because of the date conventions of pandas
-        daterange = np.arange(self.backtesting_from * 1000000,
-                              self.backtesting_to * 1000000,
-                              self.timeframe_calc * 1000000)
+        daterange = np.arange(self.backtesting_from,
+                              self.backtesting_to,
+                              self.timeframe_calc)
 
         for pair, data in self.history_data.items():
 


### PR DESCRIPTION
# Fixes
<!-- Link the corresponding issue number  -->
Fixes #84


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
In `Datamodule` I added a method that checks for missing ticks. If more than zero prints a warning. I did not find missing data, either by looking at the data or by this method, so it does not show anything right now. Warning what exact dates/ticks are missing seems too much, maybe when after adding a `--verbose` option in the cli. 

# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->
`[WARNING] Pair 'USDT/BITC' contains 4 missing ticks`

# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->
- [ ] PR depends on #
- [ ] Script to be run


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->


# Potential Issues/Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->


# Additional Info
<!-- Write anything here that wasn't mentioned above -->