### PR TITLE
Added ability to dynamically change the stoploss in a strategy

### DIFF
--- a/data/tradingmodule.py
+++ b/data/tradingmodule.py
@@ -125,6 +125,7 @@ class TradingModule:
         # if current profit is below 0, update drawdown / check SL
         stoploss = self.strategy.stoploss(indicators, filled_ohlcv, trade)
         stoploss = float(self.config["stoploss"]) if stoploss is None else stoploss
+        trade.stoploss = stoploss
         stoploss_reached = self.check_stoploss_open_trade(trade, ohlcv, stoploss)
         roi_reached = self.check_roi_open_trade(trade, ohlcv)
         if stoploss_reached or roi_reached:

--- a/data/tradingmodule.py
+++ b/data/tradingmodule.py
@@ -119,14 +119,17 @@ class TradingModule:
         self.update_value_per_timestamp_tracking(
             trade, ohlcv)  # update total value tracking
 
-        # if current profit is below 0, update drawdown / check SL
-        stoploss = self.check_stoploss_open_trade(trade, ohlcv)
-        roi = self.check_roi_open_trade(trade, ohlcv)
-        if stoploss or roi:
-            return
-
         indicators = self.strategy.generate_indicators(data)
         filled_ohlcv = indicators.iloc[[-1]].copy()
+
+        # if current profit is below 0, update drawdown / check SL
+        stoploss = self.strategy.stoploss(indicators, filled_ohlcv, trade)
+        stoploss = float(self.config["stoploss"]) if stoploss is None else stoploss
+        stoploss_reached = self.check_stoploss_open_trade(trade, ohlcv, stoploss)
+        roi_reached = self.check_roi_open_trade(trade, ohlcv)
+        if stoploss_reached or roi_reached:
+            return
+
         signal = self.strategy.sell_signal(indicators, filled_ohlcv, trade)
 
         if signal['sell'][0] == 1:
@@ -211,7 +214,7 @@ class TradingModule:
                 roi = value
         return roi
 
-    def check_stoploss_open_trade(self, trade: Trade, ohlcv: Series) -> bool:
+    def check_stoploss_open_trade(self, trade: Trade, ohlcv: Series, stoploss: float) -> bool:
         """
         :param trade: Trade model to check
         :type trade: Trade model
@@ -223,7 +226,7 @@ class TradingModule:
         if trade.profit_percentage < 0:
             if trade.max_drawdown is None or trade.max_drawdown > trade.profit_percentage:
                 trade.max_drawdown = trade.profit_percentage
-            if trade.profit_percentage < float(self.config['stoploss']):
+            if trade.profit_percentage < stoploss:
                 self.close_trade(trade, reason="Stoploss", ohlcv=ohlcv)
                 return True
         return False

--- a/models/trade.py
+++ b/models/trade.py
@@ -22,6 +22,7 @@ class Trade:
     sell_reason = None
     opened_at = 0.0
     closed_at = 0.0
+    stoploss = 0.0
 
     def __init__(self, ohlcv: Series, trade_amount: float, date: datetime):
         self.status = 'open'


### PR DESCRIPTION
# Fixes
<!-- Link the corresponding issue number  -->
Fixes #75


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
You now have the option to change the stoploss per every tick by overriding the `stoploss` method on `Strategy`. If not provided, use configured stoploss value. This stoploss is also saved in every trade. 

I also changed some of the variable names and docstrings in `Strategy`. For instance the candle and indicator dataframes were both named `dataframe: DataFrame`. Ambiguous, and the type annotation already stated that is a `DataFrame`. 

# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->


# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->
- [ ] PR depends on #
- [ ] Script to be run


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->


# Potential Issues/Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->


# Additional Info
<!-- Write anything here that wasn't mentioned above -->