### PR TITLE
[Feat] Proper startup time

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -122,6 +122,10 @@ class BackTesting:
         overall_profit = ((budget - self.starting_capital) /
                           self.starting_capital) * 100
         max_seen_drawdown = self.calculate_max_seen_drawdown()
+        drawdown_from = datetime.fromtimestamp(max_seen_drawdown['from'] / 1000) \
+            if max_seen_drawdown['from'] != 0 else '-'
+        drawdown_to = datetime.fromtimestamp(max_seen_drawdown['to'] / 1000) \
+            if max_seen_drawdown['to'] != 0 else '-'
 
         return MainResults(tested_from=datetime.fromtimestamp(self.backtesting_from / 1000),
                            tested_to=datetime.fromtimestamp(
@@ -136,10 +140,8 @@ class BackTesting:
                            max_realized_drawdown=self.trading_module.realized_drawdown,
                            max_drawdown_single_trade=self.trading_module.max_drawdown,
                            max_seen_drawdown=max_seen_drawdown["drawdown"],
-                           drawdown_from=datetime.fromtimestamp(
-                               max_seen_drawdown['from'] / 1000),
-                           drawdown_to=datetime.fromtimestamp(
-                               max_seen_drawdown['to'] / 1000),
+                           drawdown_from=drawdown_from,
+                           drawdown_to=drawdown_to,
                            configured_stoploss=self.config['stoploss'],
                            total_fee_amount=self.trading_module.total_fee_amount)
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -87,6 +87,7 @@ class BackTesting:
             indicators = self.strategy.sell_signal(indicators)
             stoploss = self.strategy.stoploss(indicators)
             self.config['stoploss'] = stoploss if stoploss else float(self.config['stoploss'])
+            indicators.dropna(inplace=True, axis=0)
             data_dict[pair] = indicators.to_dict('index')
         return data_dict
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -87,7 +87,6 @@ class BackTesting:
             indicators = self.strategy.sell_signal(indicators)
             stoploss = self.strategy.stoploss(indicators)
             self.config['stoploss'] = stoploss if stoploss else float(self.config['stoploss'])
-            indicators.dropna(inplace=True, axis=0)
             data_dict[pair] = indicators.to_dict('index')
         return data_dict
 

--- a/backtesting/strategy.py
+++ b/backtesting/strategy.py
@@ -21,8 +21,6 @@ class Strategy(abc.ABC):
     Methods defined in strategies/*.py will overwrite these methods.
     """
 
-    min_candles = 21
-
     @abc.abstractmethod
     def generate_indicators(self, candle_data: DataFrame) -> DataFrame:
         """

--- a/config/cli.py
+++ b/config/cli.py
@@ -4,7 +4,7 @@ from config.spec import spec_type_to_python_type
 
 CLI_DESCR = "Dema Trading Engine"
 
-def adjust_config_to_cli(config: dict, spec: list[dict]):
+def adjust_config_to_cli(config: dict, spec: [dict]):
     parser = argparse.ArgumentParser(description=CLI_DESCR)
     for p in spec:
         cli = p.get("cli")
@@ -18,6 +18,3 @@ def adjust_config_to_cli(config: dict, spec: list[dict]):
         if val is not None:
             arg = utils.lower_bar_to_middle_bar(arg)
             config[arg] = val
-    
-
-

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -35,7 +35,7 @@ class DataModule:
     backtesting_to = None
 
     history_data = {}
-    ohlcv_indicators = ['time', 'open', 'high', 'low', 'close', 'volume', 'pair']
+    ohlcv_indicators = ['time', 'open', 'high', 'low', 'close', 'volume', 'pair', 'buy', 'sell']
 
     def __init__(self, config, backtesting_module):
         print('[INFO] Starting DEMA Data-module...')
@@ -148,7 +148,7 @@ class DataModule:
             start_date += np.around(asked_ticks * self.timeframe_calc)
 
         # Create pandas DataFrame and adds pair info
-        df = DataFrame(ohlcv_data, index=index, columns=self.ohlcv_indicators[:-1])
+        df = DataFrame(ohlcv_data, index=index, columns=self.ohlcv_indicators[:-3])
         df['pair'] = pair
         df['buy'] = 0
         df['sell'] = 0

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -198,6 +198,9 @@ class DataModule:
             print(
                 "[ERROR] Something went wrong parsing config. Please use yyyy-mm-dd format at 'backtesting-from', 'backtesting-to'")
 
+        if self.backtesting_from >= self.backtesting_to:
+            raise Exception("[ERROR] Backtesting periods are configured incorrectly.")
+
     def check_datafolder(self, pair: str) -> bool:
         """
         :param pair: Certain coin pair in "AAA/BBB" format

--- a/strategies/indicator_sample.py
+++ b/strategies/indicator_sample.py
@@ -12,8 +12,6 @@ class IndicatorSample(Strategy):
     This is an example custom strategy, that inherits from the main Strategy class
     """
 
-    min_candles = 21
-
     def generate_indicators(self, dataframe: DataFrame) -> DataFrame:
         """
         :param dataframe: All passed candles (current candle included!) with OHLCV data
@@ -226,18 +224,17 @@ class IndicatorSample(Strategy):
         :return: dataframe filled with buy signals
         :rtype: DataFrame
         """
-        if len(dataframe) > self.min_candles:
-            # BEGIN STRATEGY
+        # BEGIN STRATEGY
 
-            dataframe.loc[
-                (
-                    (dataframe['rsi'] < 30) &
-                    (dataframe['ema5'] < dataframe['ema21']) &
-                    (dataframe['volume'] > 0)
-                ),
-                'buy'] = 1
+        dataframe.loc[
+            (
+                (dataframe['rsi'] < 30) &
+                (dataframe['ema5'] < dataframe['ema21']) &
+                (dataframe['volume'] > 0)
+            ),
+            'buy'] = 1
 
-            # END STRATEGY
+        # END STRATEGY
 
         return dataframe
 
@@ -248,16 +245,15 @@ class IndicatorSample(Strategy):
         :return: dataframe filled with sell signals
         :rtype: DataFrame
         """
-        if len(dataframe) > self.min_candles:
-            # BEGIN STRATEGY
+        # BEGIN STRATEGY
 
-            dataframe.loc[
-                (
-                    (dataframe['rsi'] > 70) &
-                    (dataframe['volume'] > 0)
-                ),
-                'sell'] = 1
+        dataframe.loc[
+            (
+                (dataframe['rsi'] > 70) &
+                (dataframe['volume'] > 0)
+            ),
+            'sell'] = 1
 
-            # END STRATEGY
+        # END STRATEGY
 
         return dataframe

--- a/strategies/my_strategy.py
+++ b/strategies/my_strategy.py
@@ -12,8 +12,6 @@ class MyStrategy(Strategy):
     This is an example custom strategy, that inherits from the main Strategy class
     """
 
-    min_candles = 21
-
     def generate_indicators(self, dataframe: DataFrame) -> DataFrame:
         """
         :param dataframe: All passed candles (current candle included!) with OHLCV data
@@ -37,18 +35,17 @@ class MyStrategy(Strategy):
         :return: dataframe filled with buy signals
         :rtype: DataFrame
         """
-        if len(dataframe) > self.min_candles:
-            # BEGIN STRATEGY
+        # BEGIN STRATEGY
 
-            dataframe.loc[
-                (
-                    (dataframe['rsi'] < 30) &
-                    (dataframe['ema5'] < dataframe['ema21']) &
-                    (dataframe['volume'] > 0)
-                ),
-                'buy'] = 1
+        dataframe.loc[
+            (
+                (dataframe['rsi'] < 30) &
+                (dataframe['ema5'] < dataframe['ema21']) &
+                (dataframe['volume'] > 0)
+            ),
+            'buy'] = 1
 
-            # END STRATEGY
+        # END STRATEGY
 
         return dataframe
 
@@ -59,16 +56,15 @@ class MyStrategy(Strategy):
         :return: dataframe filled with sell signals
         :rtype: DataFrame
         """
-        if len(dataframe) > self.min_candles:
-            # BEGIN STRATEGY
+        # BEGIN STRATEGY
 
-            dataframe.loc[
-                (
-                    (dataframe['rsi'] > 70) &
-                    (dataframe['volume'] > 0)
-                ),
-                'sell'] = 1
+        dataframe.loc[
+            (
+                (dataframe['rsi'] > 70) &
+                (dataframe['volume'] > 0)
+            ),
+            'sell'] = 1
 
-            # END STRATEGY
+        # END STRATEGY
 
         return dataframe


### PR DESCRIPTION
# Fixes
<!-- Link the corresponding issue number  -->
Fixes #23 


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
* Since our engine is not live trading anymore, the if statement in the strategy class (```if len(dataframe) > self.min_candles:```)
has become useless. This is useless because we now populate our indicators once based on the whole dataframe, which will always pass this if statement. This is removed.
* Since generate_indicators will use certain timeframes to populate indicators, it will create NaN values until it reached the configured timeframe. If these values are used in the .loc function for generating buy or sell signals, it will always fail. Therefore, incorrect buy signals will never be generated and the 'startup time' is automatically defined.

# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->
N/A

# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->
N/A


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->
N/A

# Potential Issues/Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->
N/A

# Additional Info
<!-- Write anything here that wasn't mentioned above -->
N/A