### PR TITLE
Fix: Make sure the make command also runs with volume

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ build:
 	docker build . -t dema-engine:alpha
 
 run:
-	docker run --rm dema-engine:alpha
+	docker run --rm -v "$(shell pwd):/usr/src/engine/" dema-engine:alpha
 
 runv:
 	docker run --rm -v "$(shell pwd):/usr/src/engine/" dema-engine:alpha


### PR DESCRIPTION
# Results of merging this
Fixes issues that might arise from not running the engine with the docker volume. Running without the volume was useful in the past, but is currently unnecessary.

'make' command now has exactly the same result as the 'make runv' command.


# What has been changed?
in makefile, the runv command has been copied to the run command. runv command was left on purpose, to maintain backwards compatibility.


# Examples
N/A


# Actions to be performed before this can be merged
N/A


# Security Measures
N/A

# Potential Issues / Future considerations
In the future the command 'runv' might be phased out because it is redundant.


# Assumptions made / Things to add to the wiki
Assumption: running without volume has no current uses.

# Additional Info
N/A

