### PR TITLE
[Fix] Correct stoploss, roi #patch

### DIFF
--- a/data/tradingmodule.py
+++ b/data/tradingmodule.py
@@ -150,10 +150,10 @@ class TradingModule:
         :rtype: boolean
         """
         time_passed = datetime.fromtimestamp(ohlcv['time'] / 1000) - trade.opened_at
-        profit_percentage = (trade.profit_ratio - 1) * 100
+        profit_percentage = (ohlcv['high'] / trade.open) * 100
         roi_percentage = self.get_roi_over_time(time_passed)
         if profit_percentage > roi_percentage:
-            trade.current = ohlcv["open"] * (1 + (roi_percentage / 100))
+            trade.current = trade.open * (1 + (roi_percentage / 100))
             trade.update_profits()
             self.close_trade(trade, reason="ROI", ohlcv=ohlcv)
             return True

--- a/data/tradingmodule_config.py
+++ b/data/tradingmodule_config.py
@@ -20,8 +20,8 @@ def create_trading_module_config(config: ConfigModule):
         fee=config.fee,
         max_open_trades=config.max_open_trades,
         pairs=config.pairs,
-        roi=config.raw_config['roi'],
+        roi=config.roi,
         starting_capital=config.starting_capital,
         stoploss=config.stoploss,
-        stoploss_type=config.stoploss,
+        stoploss_type=config.stoploss_type,
     )

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -53,6 +53,7 @@ class ConfigModule(object):
         self.stoploss_type = config["stoploss-type"]
         self.max_open_trades = config["max-open-trades"]
         self.plots = config["plots"]
+        self.roi = config["roi"]
         self.currency_symbol = get_currency_symbol(self.raw_config)
 
     def load_btc_marketchange(self):

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -26,17 +26,18 @@ def test_roi():
 
     fixture.frame_with_signals['COIN/BASE'] \
         .add_entry(open=1, high=1, low=1, close=1, volume=1, buy=1, sell=0) \
-        .add_entry(open=1, high=2, low=1, close=2, volume=1, buy=0, sell=0)
+        .add_entry(open=1, high=2, low=1, close=2, volume=1, buy=0, sell=0) \
+        .add_entry(open=2, high=3, low=2, close=2, volume=1, buy=0, sell=0)
 
     fixture.trading_module_config.roi = {
-        "0": 50
+            "0": 150
     }
 
     # act
     stats = fixture.create().analyze()
 
     # assert
-    assert stats.main_results.end_capital == 147.015
+    assert stats.main_results.end_capital == 245.025
 
 
 def test_capital():
@@ -97,8 +98,8 @@ def test_stoploss():
         .add_entry(open=2, high=2, low=2, close=2, volume=1, buy=1, sell=0) \
         .add_entry(open=2, high=2, low=1, close=1, volume=1, buy=0, sell=1)
 
-    fixture.trading_module_config.stoploss = 25
-    fixture.stats_config.stoploss = 25
+    fixture.trading_module_config.stoploss = -25
+    fixture.stats_config.stoploss = -25
 
     # Act
     stats = fixture.create().analyze()

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ import rapidjson
 # Files
 from models.trade import Trade
 
-CURRENT_VERSION = "v0.6.0"
+CURRENT_VERSION = "v0.6.1"
 
 
 def get_project_root():


### PR DESCRIPTION
# Results of merging this
Fixes the way stoploss is fetched from the config style, and alters the way roi is calculated.


# What has been changed?
N/A

# Examples
N/A


# Actions to be performed before this can be merged
N/A

# Security Measures
N/A


# Potential Issues / Future considerations
N/A


# Assumptions made / Things to add to the wiki
N/A

# Additional Info
N/A

