### PR TITLE
[Fix] Stoploss and ROI both reached bug, fixed

### DIFF
--- a/data/tradingmodule.py
+++ b/data/tradingmodule.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Optional
 
 from data.tradingmodule_config import TradingModuleConfig
-from models.trade import Trade
+from models.trade import Trade, SellReason
 
 
 # ======================================================================
@@ -74,14 +74,20 @@ class TradingModule:
         stoploss_reached = self.check_stoploss_open_trade(trade, ohlcv)
         roi_reached = self.check_roi_open_trade(trade, ohlcv)
 
-        if stoploss_reached or roi_reached:
-            return  # trade is closed by stoploss or ROI
+        if stoploss_reached and roi_reached:
+            trade.current = trade.open
+            trade.update_profits()
+            self.close_trade(trade, reason=SellReason.STOPLOSS_AND_ROI, ohlcv=ohlcv)
+        elif stoploss_reached:
+            self.close_trade(trade, reason=SellReason.STOPLOSS, ohlcv=ohlcv)
+        elif roi_reached:
+            self.close_trade(trade, reason=SellReason.ROI, ohlcv=ohlcv)
         elif ohlcv['sell'] == 1:
-            self.close_trade(trade, reason="Sell signal", ohlcv=ohlcv)
+            self.close_trade(trade, reason=SellReason.SELL_SIGNAL, ohlcv=ohlcv)
         else:  # trade is not closed
             self.update_value_per_timestamp_tracking(trade, ohlcv)
 
-    def close_trade(self, trade: Trade, reason: str, ohlcv: dict) -> None:
+    def close_trade(self, trade: Trade, reason: SellReason, ohlcv: dict) -> None:
         """
         :param trade: Trade model, trade to close
         :type trade: Trade
@@ -155,7 +161,6 @@ class TradingModule:
         if profit_percentage > roi_percentage:
             trade.current = trade.open * (1 + (roi_percentage / 100))
             trade.update_profits()
-            self.close_trade(trade, reason="ROI", ohlcv=ohlcv)
             return True
         return False
 
@@ -186,7 +191,6 @@ class TradingModule:
         """
         sl_signal = trade.check_for_sl(ohlcv)
         if sl_signal:
-            self.close_trade(trade, reason="Stoploss", ohlcv=ohlcv)
             return True
         return False
 

--- a/models/trade.py
+++ b/models/trade.py
@@ -1,5 +1,7 @@
 # Libraries
 from datetime import datetime
+from enum import Enum
+from typing import Any
 
 import numpy as np
 
@@ -15,9 +17,17 @@ import numpy as np
 # ======================================================================
 
 
+class SellReason(Enum):
+    SELL_SIGNAL = "Sell Signal"
+    STOPLOSS = "Stoploss"
+    ROI = "ROI"
+    STOPLOSS_AND_ROI = "Stoploss and ROI"
+    NONE = "None"
+
 class Trade:
-    max_seen_drawdown: int = 0
-    closed_at = None
+    max_seen_drawdown: int
+    closed_at: Any
+    sell_reason: SellReason
 
     def __init__(self, ohlcv: dict, spend_amount: float, fee: float, date: datetime, sl_type: str, sl_perc: float):
         self.status = 'open'
@@ -25,15 +35,16 @@ class Trade:
         self.open = ohlcv['close']
         self.opened_at = date
         self.fee = fee
+        self.max_seen_drawdown = 0
         self.starting_amount = spend_amount
         self.lowest_seen_price = spend_amount
         self.capital = spend_amount - (spend_amount * fee)  # apply fee
         self.currency_amount = (self.capital / ohlcv['close'])
-        
+        self.sell_reason = SellReason.NONE
         self.sl_type = sl_type
         self.sl_perc = sl_perc
 
-    def close_trade(self, reason: str, date: datetime) -> None:
+    def close_trade(self, reason: SellReason, date: datetime) -> None:
         """
         Closes this trade and updates stats according to latest data.
 

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -38,14 +38,17 @@ class ConsoleColors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def show_trade_anomalies(stats: TradingStats):
 
+def show_trade_anomalies(stats: TradingStats):
     trades = list(filter(lambda x: x.sell_reason == SellReason.STOPLOSS_AND_ROI, stats.trades))
 
     if len(trades) > 0:
-        print_warning("WARNING: Stoploss and ROI reached for trade in single OHLCV")
+        print_warning("WARNING: Both Stoploss and ROI were triggered in the same OHLCV candle")
+        print_warning("during the following trades:")
         for trade in trades:
-            print_warning(f"Trade opened at {trade.opened_at}")
+            print_warning(f"- {trade.opened_at} ==> {trade.closed_at}")
+        print_warning("profit for effected trades will be set to 0%")
+
 
 def print_warning(text):
     print(f"{ConsoleColors.WARNING}{text}{ConsoleColors.ENDC}")

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -1,4 +1,7 @@
+from enum import Enum
+
 from backtesting.results import show_signature
+from models.trade import SellReason
 from modules.stats.stats_config import StatsConfig
 from modules.stats.trading_stats import TradingStats
 
@@ -14,8 +17,35 @@ class OutputModule(object):
         stats.main_results.show(self.config.currency_symbol)
         # CoinInsights.show(stats.coin_res, self.config.currency_symbol)
         # OpenTradeResult.show(stats.open_trade_res, self.config.currency_symbol)
+
+        show_trade_anomalies(stats)
+
         show_signature()
 
         # plot graphs
         # if self.config.plots:
         #     plot_per_coin(stats.frame_with_signals, stats.df, self.config, stats.buypoints, stats.sellpoints)
+
+
+class ConsoleColors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def show_trade_anomalies(stats: TradingStats):
+
+    trades = list(filter(lambda x: x.sell_reason == SellReason.STOPLOSS_AND_ROI, stats.trades))
+
+    if len(trades) > 0:
+        print_warning("WARNING: Stoploss and ROI reached for trade in single OHLCV")
+        for trade in trades:
+            print_warning(f"Trade opened at {trade.opened_at}")
+
+def print_warning(text):
+    print(f"{ConsoleColors.WARNING}{text}{ConsoleColors.ENDC}")

--- a/modules/stats/trading_stats.py
+++ b/modules/stats/trading_stats.py
@@ -15,3 +15,4 @@ class TradingStats:
     buypoints: dict
     sellpoints: dict
     df: DataFrame
+    trades: list

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -1,0 +1,57 @@
+from collections import Callable
+
+import pandas as pd
+
+from data.tradingmodule import TradingModule
+from data.tradingmodule_config import TradingModuleConfig
+from modules.stats.stats import StatsModule
+from modules.stats.stats_config import StatsConfig
+from test.utils.signal_frame import MockPairFrame
+from utils import get_ohlcv_indicators
+
+StatsModuleFactory = Callable[[], StatsModule]
+
+max_open_trades = 3
+STARTING_CAPITAL = 100.
+FEE_PERCENTAGE = 1
+
+STOPLOSS = 100
+
+OHLCV_INDICATORS = get_ohlcv_indicators()
+
+
+class StatsFixture:
+
+    def __init__(self, pairs: list):
+        self.stats_config = StatsConfig(
+            max_open_trades=max_open_trades,
+            starting_capital=100,
+            backtesting_from=1,
+            backtesting_to=10,
+            btc_marketchange_ratio=1,
+            fee=FEE_PERCENTAGE,
+
+            stoploss=STOPLOSS,
+            currency_symbol="USDT",
+            plots=False,
+
+            plot_indicators1=[],
+            plot_indicators2=[]
+        )
+
+        self.trading_module_config = TradingModuleConfig(
+            stoploss=STOPLOSS,
+            max_open_trades=max_open_trades,
+            starting_capital=STARTING_CAPITAL,
+            fee=FEE_PERCENTAGE,
+            pairs=pairs,
+            stoploss_type="standard",
+            roi={"0": int(9999999999)}
+        )
+
+        self.frame_with_signals = MockPairFrame(pairs)
+
+    def create(self):
+        df = pd.DataFrame.from_dict(self.frame_with_signals, orient='index', columns=OHLCV_INDICATORS)
+        trading_module = TradingModule(self.trading_module_config)
+        return StatsModule(self.stats_config, self.frame_with_signals, trading_module, df)

--- a/test/stats/test_roi_stoploss.py
+++ b/test/stats/test_roi_stoploss.py
@@ -1,0 +1,45 @@
+from test.stats.stats_test_utils import StatsFixture
+
+
+def test_roi():
+    """given `value of coin rises over ROI limit` should sell at ROI price"""
+    # arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'] \
+        .add_entry(open=1, high=1, low=1, close=1, volume=1, buy=1, sell=0) \
+        .add_entry(open=1, high=2, low=1, close=2, volume=1, buy=0, sell=0) \
+        .add_entry(open=2, high=3, low=2, close=2, volume=1, buy=0, sell=0)
+
+    fixture.trading_module_config.roi = {
+        "0": 150
+    }
+
+    # act
+    stats = fixture.create().analyze()
+
+    # assert
+    assert stats.main_results.end_capital == 245.025
+
+
+def test_both_roi_stoploss():
+    """"""
+    # arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'] \
+        .add_entry(open=1, high=1, low=1, close=1, volume=1, buy=1, sell=0) \
+        .add_entry(open=1, high=2, low=0.1, close=2, volume=1, buy=0, sell=0)
+
+    fixture.trading_module_config.roi = {
+        "0": 50
+    }
+
+    fixture.trading_module_config.stoploss = -50
+    fixture.stats_config.stoploss = -50
+
+    # act
+    stats = fixture.create().analyze()
+
+    # assert
+    assert stats.main_results.end_capital == 98.01

--- a/test/stats/test_roi_stoploss.py
+++ b/test/stats/test_roi_stoploss.py
@@ -23,7 +23,7 @@ def test_roi():
 
 
 def test_both_roi_stoploss():
-    """"""
+    """given 'both ROI and stoploss triggered single OHLCV candle' should 'close trade for open price'"""
     # arrange
     fixture = StatsFixture(['COIN/BASE'])
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -232,7 +232,7 @@ def test_simple_realized_drawdown():
     assert math.isclose(stats.main_results.max_realised_drawdown, -38.74375)
 
 def test_simple_no_realized_drawdown():
-    """Given 'sell at half value', 'realized drawdown' should 'be half'"""
+    """Given 'no drawdown trades', 'realized drawdown' should 'none'"""
     # Arrange
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE'])
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -1,43 +1,7 @@
 import math
-from typing import Callable
-
-import pandas as pd
-
-from data.tradingmodule import TradingModule
-from data.tradingmodule_config import TradingModuleConfig
-from modules.stats.stats import StatsModule
-from modules.stats.stats_config import StatsConfig
-from test.utils.signal_frame import MockPairFrame, TradeAction
+from test.stats.stats_test_utils import StatsFixture
+from test.utils.signal_frame import TradeAction
 from utils import get_ohlcv_indicators
-
-max_open_trades = 3
-STARTING_CAPITAL = 100.
-FEE_PERCENTAGE = 1
-
-STOPLOSS = 100
-
-OHLCV_INDICATORS = get_ohlcv_indicators()
-
-
-def test_roi():
-    """given `value of coin rises over ROI limit` should sell at ROI price"""
-    # arrange
-    fixture = StatsFixture(['COIN/BASE'])
-
-    fixture.frame_with_signals['COIN/BASE'] \
-        .add_entry(open=1, high=1, low=1, close=1, volume=1, buy=1, sell=0) \
-        .add_entry(open=1, high=2, low=1, close=2, volume=1, buy=0, sell=0) \
-        .add_entry(open=2, high=3, low=2, close=2, volume=1, buy=0, sell=0)
-
-    fixture.trading_module_config.roi = {
-        "0": 150
-    }
-
-    # act
-    stats = fixture.create().analyze()
-
-    # assert
-    assert stats.main_results.end_capital == 245.025
 
 
 def test_capital():
@@ -408,41 +372,5 @@ def test_best_worst_trade():
     assert math.isclose(stats.main_results.max_drawdown_single_trade, -50.995)
 
 
-StatsModuleFactory = Callable[[], StatsModule]
 
 
-class StatsFixture:
-
-    def __init__(self, pairs: list):
-        self.stats_config = StatsConfig(
-            max_open_trades=max_open_trades,
-            starting_capital=100,
-            backtesting_from=1,
-            backtesting_to=10,
-            btc_marketchange_ratio=1,
-            fee=FEE_PERCENTAGE,
-
-            stoploss=STOPLOSS,
-            currency_symbol="USDT",
-            plots=False,
-
-            plot_indicators1=[],
-            plot_indicators2=[]
-        )
-
-        self.trading_module_config = TradingModuleConfig(
-            stoploss=STOPLOSS,
-            max_open_trades=max_open_trades,
-            starting_capital=STARTING_CAPITAL,
-            fee=FEE_PERCENTAGE,
-            pairs=pairs,
-            stoploss_type="standard",
-            roi={"0": int(9999999999)}
-        )
-
-        self.frame_with_signals = MockPairFrame(pairs)
-
-    def create(self):
-        df = pd.DataFrame.from_dict(self.frame_with_signals, orient='index', columns=OHLCV_INDICATORS)
-        trading_module = TradingModule(self.trading_module_config)
-        return StatsModule(self.stats_config, self.frame_with_signals, trading_module, df)

--- a/utils.py
+++ b/utils.py
@@ -42,14 +42,6 @@ def default_empty_array_dict() -> list:
     return []
 
 
-def default_empty_dict_dict() -> dict:
-    """
-    :return: dictionary for initializing default dictionary
-    :rtype: dict
-    """
-    return defaultdict(int)
-
-
 def calculate_worth_of_open_trades(open_trades: [Trade]) -> float:
     """
     Method calculates worth of open trades


### PR DESCRIPTION
# Results of merging this
Fixed a bug that was triggered when both ROI and stoploss values are reached in one candle

# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->


# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->


# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->


# Potential Issues / Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->


# Assumptions made / Things to add to the wiki
<!-- Did you make any assumptions during this development? Certain flows or logic? This could be quite broad, but it's
 very crucial to avoid misconceptions regarding the working of the engine --> 
Add to the wiki:
Explanation about ROI & Stoploss warning and what to do to avoid it

# Additional Info
<!-- Write anything here that wasn't mentioned above -->

