### PR TITLE
Remove graph zoom out due to buy signals with value zero

### DIFF
--- a/modules/output/plots.py
+++ b/modules/output/plots.py
@@ -52,6 +52,9 @@ def add_buy_sell_signal(fig, df, dates):
     buy_signals = df["buy"] * df["close"]
     sell_signals = df["sell"] * df["close"]
 
+    buy_signals = buy_signals.replace(0, np.nan)
+    sell_signals = sell_signals.replace(0, np.nan)
+
     fig.add_trace((go.Scatter(x=dates, y=buy_signals,
                               mode='markers', name='buysignal', line_color='rgb(0,255,0)')), row=1, col=1)
     fig.add_trace((go.Scatter(x=dates, y=sell_signals,


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes a bug that zooms the main plot out due to zero values in the buy & sell signals, instead of nan values


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->


# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->


# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->
- [ ] PR depends on #
- [ ] Script to be run


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->


# Potential Issues / Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->


# Assumptions made / Things to add to the wiki
<!-- Did you make any assumptions during this development? Certain flows or logic? This could be quite broad, but it's
 very crucial to avoid misconceptions regarding the working of the engine --> 

# Packages added
<!-- Did you add new packages to the code? What are the licences of the packages? Make sure to only add packages
 that are allowed to be used in the engine -->

# Additional Info
<!-- Write anything here that wasn't mentioned above -->
