### PR TITLE
Fix/average trade alignment

### DIFF
--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -63,7 +63,7 @@ class MainResults:
         print("| Overall profit: \t\t%s" %
               round(self.overall_profit_percentage, 2) + '\t%')
         print("| Amount of trades: \t\t%s" % self.n_trades)
-        print("| Average trades per day: \t\t%s" % round(self.n_average_trades, 2))
+        print("| Average trades per day: \t%s" % round(self.n_average_trades, 2))
         print("| Left-open trades: \t\t%s" % self.n_left_open_trades)
         print("| Trades with loss: \t\t%s" % self.n_trades_with_loss)
         print("| Most consecutive losses: \t%s" % self.n_consecutive_losses)


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes the alignment of the average trade statistic in the backtesting results overview


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
removes a tab!
