### PR TITLE
Fix/run fails when datafile corrupted

### DIFF
--- a/modules/setup/datamodule.py
+++ b/modules/setup/datamodule.py
@@ -50,7 +50,11 @@ class DataModule:
     async def get_pair_data(self, pair):
         if self.is_datafolder_exist(pair):
             print("[INFO] Reading datafile for %s." % pair)
-            df = await self.read_data_from_datafile(pair)
+            try:
+                df = await self.read_data_from_datafile(pair)
+            except rapidjson.JSONDecodeError:
+                print("[INFO] Unable to read datafile for %s, starting download..." % pair)
+                df = await self.download_data_for_pair(pair, self.config.backtesting_from, self.config.backtesting_to)
         else:
             print("[INFO] Did not find datafile for %s, starting download..." % pair)
             df = await self.download_data_for_pair(pair, self.config.backtesting_from, self.config.backtesting_to)
@@ -143,15 +147,16 @@ class DataModule:
         try:
             with open(filepath, 'r') as datafile:
                 data = datafile.read()
+                df = dict_to_df(data)
         except FileNotFoundError:
             print("[ERROR] Backtesting datafile was not found.")
             return None
         except EnvironmentError:
             print("[ERROR] Something went wrong loading datafile", sys.exc_info()[0])
             return None
-
-        # Convert json to dataframe
-        df = dict_to_df(data)
+        except rapidjson.JSONDecodeError:
+            os.remove(filepath)
+            raise
 
         # Find correct last tick timestamp
         n_downloaded_candles = (self.config.backtesting_to - self.config.backtesting_from) / self.config.timeframe_ms


### PR DESCRIPTION
# Results of merging this
Fixes #284 


# What has been changed?
Add re-downloading of datafiles when they are unreadable