### PR TITLE
Fix/max realised drawdown simple

### DIFF
--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -39,20 +39,21 @@ class MainResults:
     worst_trade_profit_percentage: float
     best_trade_profit_percentage: float
     max_seen_drawdown: float
-    drawdown_from: datetime
-    drawdown_to: datetime
-    drawdown_at: datetime
+    drawdown_from: str
+    drawdown_to: str
+    drawdown_at: str
     configured_stoploss: float
     fee: float
     total_fee_amount: float
 
     def show(self, currency_symbol: str):
+
         print("================================================= \n| %sBacktesting Results%s "
               "\n=================================================" % (FONT_BOLD, FONT_RESET))
         print("| Engine version \t\t%s" % CURRENT_VERSION)
         print("| ")
-        print("| Backtesting from: \t\t%s" % self.tested_from)
-        print("| Backtesting to: \t\t%s" % self.tested_to)
+        print("| Backtesting from: \t\t%s" % self.tested_from.strftime('%Y-%m-%d ''%H:%M'))
+        print("| Backtesting to: \t\t%s" % self.tested_to.strftime('%Y-%m-%d ''%H:%M'))
         print("| Max open trades: \t\t%s" % self.max_open_trades)
         print("| Stoploss: \t\t\t%s" % self.configured_stoploss + "\t%")
         print("| ")

--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+from modules.stats.drawdown.drawdown import get_max_drawdown_ratio
+
 
 def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
     max_seen_drawdown = {}
@@ -23,8 +25,6 @@ def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
 
 def get_max_realised_drawdown_for_portfolio(realised_profits_per_timestamp: dict):
     df = pd.DataFrame.from_dict(realised_profits_per_timestamp, columns=['value'], orient='index')
-    df["drawdown"] = df["value"] / df["value"].cummax()
-
-    max_realised_drawdown = df["drawdown"].min()
+    max_realised_drawdown = get_max_drawdown_ratio(df)
 
     return max_realised_drawdown

--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -18,3 +18,23 @@ def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
     max_seen_drawdown["to"] = df.loc[max_seen_drawdown["at"]:].drawdown.eq(0.0).idxmax()
 
     return max_seen_drawdown
+
+
+def get_max_realised_drawdown_for_portfolio(realised_profits_per_timestamp: dict):
+    max_realised_drawdown = {
+        "drawdown": 1.0,  # ratio
+        "max_consecutive_losses": 0,
+        "losing_trades": 0
+    }
+
+    df = pd.DataFrame.from_dict(realised_profits_per_timestamp, columns=['value'], orient='index')
+    df["drawdown"] = (df["value"] - df["value"].cummax()) / df["value"].cummax()
+    df['losing_trade'] = df.value.lt(df.value.shift())
+
+    df['consecutive_losses'] = df.losing_trade.cumsum()-df.losing_trade.cumsum().where(~df.losing_trade).ffill().fillna(0).astype(int)
+
+    max_realised_drawdown['drawdown'] = df["drawdown"].min()
+    max_realised_drawdown['losing_trades'] = df["losing_trade"].value_counts().loc[True]
+    max_realised_drawdown['max_consecutive_losses'] = df["consecutive_losses"].max()
+
+    return max_realised_drawdown

--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -23,27 +23,9 @@ def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
 
 
 def get_max_realised_drawdown_for_portfolio(realised_profits_per_timestamp: dict):
-    max_realised_drawdown = {
-        "drawdown": 1.0,  # ratio
-        "max_consecutive_losses": 0,
-        "losing_trades": 0
-    }
-
     df = pd.DataFrame.from_dict(realised_profits_per_timestamp, columns=['value'], orient='index')
-    df["drawdown"] = (df["value"] - df["value"].cummax()) / df["value"].cummax()
-    df['losing_trade'] = df.value.lt(df.value.shift())
+    df["drawdown"] = df["value"] / df["value"].cummax()
 
-    df['consecutive_losses'] = df.losing_trade.cumsum()-df.losing_trade.cumsum().where(~df.losing_trade)\
-        .ffill()\
-        .fillna(0)\
-        .astype(int)
-
-    max_realised_drawdown['drawdown'] = df["drawdown"].min()
-    losing_trades_count = df["losing_trade"].value_counts()
-    if True in losing_trades_count:
-        max_realised_drawdown['losing_trades'] = losing_trades_count.loc[True]
-    else:
-        max_realised_drawdown['losing_trades'] = 0
-    max_realised_drawdown['max_consecutive_losses'] = df["consecutive_losses"].max()
+    max_realised_drawdown = df["drawdown"].min()
 
     return max_realised_drawdown

--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -39,7 +39,11 @@ def get_max_realised_drawdown_for_portfolio(realised_profits_per_timestamp: dict
         .astype(int)
 
     max_realised_drawdown['drawdown'] = df["drawdown"].min()
-    max_realised_drawdown['losing_trades'] = df["losing_trade"].value_counts().loc[True]
+    losing_trades_count = df["losing_trade"].value_counts()
+    if True in losing_trades_count:
+        max_realised_drawdown['losing_trades'] = losing_trades_count.loc[True]
+    else:
+        max_realised_drawdown['losing_trades'] = 0
     max_realised_drawdown['max_consecutive_losses'] = df["consecutive_losses"].max()
 
     return max_realised_drawdown

--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -15,6 +15,7 @@ def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
     max_seen_drawdown["drawdown"] = df["drawdown"].min()
     max_seen_drawdown["at"] = df["drawdown"].idxmin()
     max_seen_drawdown["from"] = df.loc[:max_seen_drawdown["at"]].value.idxmax()
+
     max_seen_drawdown["to"] = df.loc[max_seen_drawdown["at"]:].drawdown.eq(0.0).idxmax()
 
     return max_seen_drawdown
@@ -31,7 +32,10 @@ def get_max_realised_drawdown_for_portfolio(realised_profits_per_timestamp: dict
     df["drawdown"] = (df["value"] - df["value"].cummax()) / df["value"].cummax()
     df['losing_trade'] = df.value.lt(df.value.shift())
 
-    df['consecutive_losses'] = df.losing_trade.cumsum()-df.losing_trade.cumsum().where(~df.losing_trade).ffill().fillna(0).astype(int)
+    df['consecutive_losses'] = df.losing_trade.cumsum()-df.losing_trade.cumsum().where(~df.losing_trade)\
+        .ffill()\
+        .fillna(0)\
+        .astype(int)
 
     max_realised_drawdown['drawdown'] = df["drawdown"].min()
     max_realised_drawdown['losing_trades'] = df["losing_trade"].value_counts().loc[True]

--- a/modules/stats/drawdown/per_coin.py
+++ b/modules/stats/drawdown/per_coin.py
@@ -61,7 +61,7 @@ def find_trade_timestamps(closed_pair_trades):
 
 
 def get_max_realised_drawdown_per_coin(signal_dict, closed_pair_trades: [Trade], fee_percentage: float):
-    trades_open_closed_timestamps = map_trades_to_open_close_timestamps(closed_pair_trades)
+    trades_open_closed_timestamps = map_trades_to_opened_closed_timestamps(closed_pair_trades)
     trade_timestamps = find_trade_timestamps(closed_pair_trades)
 
     values = signal_dict.values()

--- a/modules/stats/drawdown/per_coin.py
+++ b/modules/stats/drawdown/per_coin.py
@@ -49,3 +49,32 @@ def add_trade_fee(df, fee_percentage, trades_closed_open):
     for open, close in trades_closed_open:
         df.loc[open, "profit_ratio"] *= fee_ratio
         df.loc[close, "profit_ratio"] *= fee_ratio
+
+
+def find_trade_timestamps(closed_pair_trades):
+    trade_timestamps_list = []
+    for trade in closed_pair_trades:
+        trade_timestamps_list.append(int(trade.opened_at.timestamp() * 1000))
+        trade_timestamps_list.append(int(trade.closed_at.timestamp() * 1000))
+    trade_timestamps = pd.DataFrame(trade_timestamps_list, columns=["time"]).set_index("time")
+    return trade_timestamps
+
+
+def get_max_realised_drawdown_per_coin(signal_dict, closed_pair_trades: [Trade], fee_percentage: float):
+    trades_open_closed_timestamps = map_trades_to_open_close_timestamps(closed_pair_trades)
+    trade_timestamps = find_trade_timestamps(closed_pair_trades)
+
+    values = signal_dict.values()
+    df = pd.DataFrame(values).set_index("time")
+
+    df = pd.concat([df, trade_timestamps], axis=1, join="inner")
+
+    # Copy first row to zero index to save asset value before applying fees
+    df = with_copied_initial_row(df)
+
+    apply_profit_ratio(df, trades_open_closed_timestamps)
+    add_trade_fee(df, fee_percentage, trades_open_closed_timestamps)
+
+    df["value"] = df["profit_ratio"].cumprod()
+
+    return get_max_drawdown_ratio(df)

--- a/modules/stats/drawdown/per_coin.py
+++ b/modules/stats/drawdown/per_coin.py
@@ -51,7 +51,7 @@ def add_trade_fee(df, fee_percentage, trades_closed_opened):
         df.loc[closed, "profit_ratio"] *= fee_ratio
 
 
-def find_trade_timestamps(closed_pair_trades):
+def get_trade_timestamps(closed_pair_trades):
     trade_timestamps_list = []
     for trade in closed_pair_trades:
         trade_timestamps_list.append(int(trade.opened_at.timestamp() * 1000))
@@ -62,7 +62,7 @@ def find_trade_timestamps(closed_pair_trades):
 
 def get_max_realised_drawdown_per_coin(signal_dict, closed_pair_trades: [Trade], fee_percentage: float):
     trades_open_closed_timestamps = map_trades_to_opened_closed_timestamps(closed_pair_trades)
-    trade_timestamps = find_trade_timestamps(closed_pair_trades)
+    trade_timestamps = get_trade_timestamps(closed_pair_trades)
 
     values = signal_dict.values()
     df = pd.DataFrame(values).set_index("time")

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from modules.output.results import CoinInsights, MainResults, OpenTradeResult
 from modules.pairs_data import PairsData
-from modules.stats.drawdown.per_coin import get_max_seen_drawdown_per_coin
+from modules.stats.drawdown.per_coin import get_max_seen_drawdown_per_coin, get_max_realised_drawdown_per_coin
 from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portfolio, \
     get_max_realised_drawdown_for_portfolio
 from modules.stats.drawdown.per_trade import get_max_seen_drawdown_per_trade
@@ -186,6 +186,8 @@ class StatsModule:
         for key, closed_pair_trades in trades_per_coin.items():
             seen_drawdown_per_coin = get_max_seen_drawdown_per_coin(self.frame_with_signals[key], closed_pair_trades, self.config.fee)
             per_coin_stats[key]["max_seen_ratio"] = seen_drawdown_per_coin
+            realised_drawdown_per_coin = get_max_realised_drawdown_per_coin(self.frame_with_signals[key], closed_pair_trades, self.config.fee)
+            per_coin_stats[key]["max_realised_ratio"] = realised_drawdown_per_coin
 
         for trade in closed_trades:
 

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -42,8 +42,7 @@ def get_number_of_consecutive_losing_trades(closed_trades):
             temp_nr_consecutive_trades += 1
         else:
             temp_nr_consecutive_trades = 0
-        if temp_nr_consecutive_trades > nr_consecutive_trades:
-            nr_consecutive_trades = temp_nr_consecutive_trades
+        nr_consecutive_trades =  max(temp_nr_consecutive_trades, nr_consecutive_trades)
     return nr_consecutive_trades
 
 

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -5,7 +5,8 @@ import numpy as np
 from modules.output.results import CoinInsights, MainResults, OpenTradeResult
 from modules.pairs_data import PairsData
 from modules.stats.drawdown.per_coin import get_max_seen_drawdown_per_coin
-from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portfolio
+from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portfolio, \
+    get_max_realised_drawdown_for_portfolio
 from modules.stats.drawdown.per_trade import get_max_seen_drawdown_per_trade
 from modules.stats.stats_config import StatsConfig
 from modules.stats.trade import Trade, SellReason
@@ -15,7 +16,6 @@ from collections import defaultdict
 
 from utils.dict import group_by
 from utils.utils import calculate_worth_of_open_trades
-
 
 
 def calculate_best_worst_trade(closed_trades):
@@ -30,8 +30,8 @@ def calculate_best_worst_trade(closed_trades):
 
 
 class StatsModule:
-    buypoints = None
-    sellpoints = None
+    buy_points = None
+    sell_points = None
 
     def __init__(self, config: StatsConfig, frame_with_signals: PairsData, trading_module: TradingModule, df):
         self.df = df
@@ -73,8 +73,8 @@ class StatsModule:
             coin_res=coin_res,
             open_trade_res=open_trade_res,
             frame_with_signals=self.frame_with_signals,
-            buypoints=self.buypoints,
-            sellpoints=self.sellpoints,
+            buypoints=self.buy_points,
+            sellpoints=self.sell_points,
             df=self.df,
             trades=trading_module.open_trades + trading_module.closed_trades
         )
@@ -86,9 +86,12 @@ class StatsModule:
         overall_profit_percentage = ((budget - self.config.starting_capital) / self.config.starting_capital) * 100
 
         # Find max seen and realised drawdown
-        max_realised_drawdown = self.calculate_max_realised_drawdown()
-
-        max_seen_drawdown = get_max_seen_drawdown_for_portfolio(self.trading_module.capital_per_timestamp)
+        max_realised_drawdown = get_max_realised_drawdown_for_portfolio(
+            self.trading_module.realised_profits_per_timestamp
+        )
+        max_seen_drawdown = get_max_seen_drawdown_for_portfolio(
+            self.trading_module.capital_per_timestamp
+        )
 
         # Update variables for prettier terminal output
         drawdown_from = datetime.fromtimestamp(max_seen_drawdown['from'] / 1000).strftime('%Y-%m-%d ''%H:%M') \
@@ -103,16 +106,14 @@ class StatsModule:
             if worst_trade_ratio != np.inf else 0
 
         tested_from = datetime.fromtimestamp(self.config.backtesting_from / 1000)
-        tested_from_string = tested_from.strftime('%Y-%m-%d ''%H:%M')
         tested_to = datetime.fromtimestamp(
             self.config.backtesting_to / 1000)
-        tested_to_string = tested_to.strftime('%Y-%m-%d ''%H:%M')
 
         timespan_seconds = (tested_to - tested_from).total_seconds()
         nr_days = timespan_seconds / timedelta(days=1).total_seconds()
 
-        return MainResults(tested_from=tested_from_string,
-                           tested_to=tested_to_string,
+        return MainResults(tested_from=tested_from,
+                           tested_to=tested_to,
                            max_open_trades=self.config.max_open_trades,
                            market_change_coins=(market_change['all'] - 1) * 100,
                            market_change_btc=(self.config.btc_marketchange_ratio - 1) * 100,
@@ -122,9 +123,9 @@ class StatsModule:
                            n_trades=len(open_trades) + len(closed_trades),
                            n_average_trades=(len(open_trades) + len(closed_trades)) / nr_days,
                            n_left_open_trades=len(open_trades),
-                           n_trades_with_loss=max_realised_drawdown['drawdown_trades'],
+                           n_trades_with_loss=max_realised_drawdown['losing_trades'],
                            n_consecutive_losses=max_realised_drawdown['max_consecutive_losses'],
-                           max_realised_drawdown=(max_realised_drawdown['max_drawdown'] - 1) * 100,
+                           max_realised_drawdown=max_realised_drawdown['drawdown'] * 100,
                            worst_trade_profit_percentage=worst_trade_profit_percentage,
                            best_trade_profit_percentage=best_trade_profit_percentage,
                            max_seen_drawdown=max_seen_drawdown['drawdown'] * 100,
@@ -183,8 +184,8 @@ class StatsModule:
         trades_per_coin = group_by(closed_trades, "pair")
 
         for key, closed_pair_trades in trades_per_coin.items():
-            drawdown_per_coin = get_max_seen_drawdown_per_coin(self.frame_with_signals[key], closed_pair_trades, self.config.fee)
-            per_coin_stats[key]["max_seen_ratio"] = drawdown_per_coin
+            seen_drawdown_per_coin = get_max_seen_drawdown_per_coin(self.frame_with_signals[key], closed_pair_trades, self.config.fee)
+            per_coin_stats[key]["max_seen_ratio"] = seen_drawdown_per_coin
 
         for trade in closed_trades:
 
@@ -211,70 +212,20 @@ class StatsModule:
                 per_coin_stats[trade.pair]['total_duration'] += trade.closed_at - trade.opened_at
         return per_coin_stats
 
-    def calculate_max_realised_drawdown(self) -> dict:
-        """
-        Method calculates max seen drawdown based on the saved budget / value changes
-        :return: returns max_seen_drawdown as a dictionary
-        :rtype: dictionary
-        """
-        max_realised_drawdown = {
-            "total_ratio": 1,
-            "peak_ratio": 1,
-            "curr_drawdown": 1,  # ratio
-            "max_drawdown": 1,  # ratio
-            "curr_consecutive_losses": 0,
-            "max_consecutive_losses": 0,
-            "drawdown_trades": 0
-        }
-
-        realised_profits = self.trading_module.realised_profits
-        prev_profit = self.config.starting_capital
-
-        for new_profit in realised_profits:
-            profit_ratio = new_profit / prev_profit
-
-            # Update consecutive losses
-            if profit_ratio < 1:
-                max_realised_drawdown['curr_consecutive_losses'] += 1
-                max_realised_drawdown['drawdown_trades'] += 1
-            else:
-                max_realised_drawdown['curr_consecutive_losses'] = 0
-
-            # Check if max consecutive losses is beaten
-            if max_realised_drawdown['curr_consecutive_losses'] > max_realised_drawdown['max_consecutive_losses']:
-                max_realised_drawdown['max_consecutive_losses'] = max_realised_drawdown['curr_consecutive_losses']
-
-            # Update curr and total ratio
-            max_realised_drawdown['curr_drawdown'] *= profit_ratio
-            max_realised_drawdown['total_ratio'] *= profit_ratio
-
-            # Check for max realised drawdown
-            if max_realised_drawdown['curr_drawdown'] < max_realised_drawdown['max_drawdown']:
-                max_realised_drawdown['max_drawdown'] = max_realised_drawdown['curr_drawdown']
-
-            # Check for new ratio high
-            if max_realised_drawdown['total_ratio'] > max_realised_drawdown['peak_ratio']:
-                max_realised_drawdown['peak_ratio'] = max_realised_drawdown['total_ratio']
-                max_realised_drawdown['curr_drawdown'] = 1.0  # reset ratio
-
-            prev_profit = new_profit
-
-        return max_realised_drawdown
-
     def calculate_statistics_for_plots(self, closed_trades, open_trades):
 
         # Used for plotting
-        self.buypoints = {pair: [] for pair in self.frame_with_signals.keys()}
-        self.sellpoints = {pair: [] for pair in self.frame_with_signals.keys()}
+        self.buy_points = {pair: [] for pair in self.frame_with_signals.keys()}
+        self.sell_points = {pair: [] for pair in self.frame_with_signals.keys()}
 
         for trade in closed_trades:
             # Save buy/sell signals
-            self.buypoints[trade.pair].append(trade.opened_at)
-            self.sellpoints[trade.pair].append(trade.closed_at)
+            self.buy_points[trade.pair].append(trade.opened_at)
+            self.sell_points[trade.pair].append(trade.closed_at)
 
         for trade in open_trades:
             # Save buy/sell signals
-            self.buypoints[trade.pair].append(trade.opened_at)
+            self.buy_points[trade.pair].append(trade.opened_at)
 
     def generate_open_trades_results(self, open_trades: [Trade]) -> list:
         open_trade_stats = []
@@ -291,18 +242,6 @@ class StatsModule:
 
 
 def get_market_change(ticks: list, pairs: list, data_dict: dict) -> dict:
-    """
-    Calculates the market change for every coin if bought at start and sold at end.
-
-    :param ticks: list with all ticks
-    :type ticks: list
-    :param pairs: list of traded pairs
-    :type pairs: list
-    :param data_dict: dict containing OHLCV data per pair
-    :type data_dict: dict
-    :return: dict with market change per pair
-    :rtype: dict
-    """
     market_change = {}
     total_change = 0
     for pair in pairs:

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -29,6 +29,24 @@ def calculate_best_worst_trade(closed_trades):
     return best_trade_ratio, worst_trade_ratio
 
 
+def get_number_of_losing_trades(closed_trades: [Trade]) -> int:
+    nr_losing_trades = sum(1 for trade in closed_trades if trade.profit_ratio <= 1)
+    return nr_losing_trades
+
+
+def get_number_of_consecutive_losing_trades(closed_trades):
+    nr_consecutive_trades = 0
+    temp_nr_consecutive_trades = 0
+    for trade in closed_trades:
+        if trade.profit_ratio <= 1:
+            temp_nr_consecutive_trades += 1
+        else:
+            temp_nr_consecutive_trades = 0
+        if temp_nr_consecutive_trades > nr_consecutive_trades:
+            nr_consecutive_trades = temp_nr_consecutive_trades
+    return nr_consecutive_trades
+
+
 class StatsModule:
     buy_points = None
     sell_points = None
@@ -93,6 +111,9 @@ class StatsModule:
             self.trading_module.capital_per_timestamp
         )
 
+        nr_losing_trades = get_number_of_losing_trades(closed_trades)
+        nr_consecutive_losing_trades = get_number_of_consecutive_losing_trades(closed_trades)
+
         # Update variables for prettier terminal output
         drawdown_from = datetime.fromtimestamp(max_seen_drawdown['from'] / 1000).strftime('%Y-%m-%d ''%H:%M') \
             if max_seen_drawdown['from'] != 0 else '-'
@@ -123,9 +144,9 @@ class StatsModule:
                            n_trades=len(open_trades) + len(closed_trades),
                            n_average_trades=(len(open_trades) + len(closed_trades)) / nr_days,
                            n_left_open_trades=len(open_trades),
-                           n_trades_with_loss=max_realised_drawdown['losing_trades'],
-                           n_consecutive_losses=max_realised_drawdown['max_consecutive_losses'],
-                           max_realised_drawdown=max_realised_drawdown['drawdown'] * 100,
+                           n_trades_with_loss=nr_losing_trades,
+                           n_consecutive_losses=nr_consecutive_losing_trades,
+                           max_realised_drawdown=(max_realised_drawdown-1) * 100,
                            worst_trade_profit_percentage=worst_trade_profit_percentage,
                            best_trade_profit_percentage=best_trade_profit_percentage,
                            max_seen_drawdown=(max_seen_drawdown['drawdown']-1) * 100,

--- a/modules/stats/tradingmodule.py
+++ b/modules/stats/tradingmodule.py
@@ -32,10 +32,10 @@ class TradingModule:
         self.open_trades = []
         self.budget_per_timestamp = {}
         self.capital_per_timestamp = {0: self.budget}
+        self.realised_profits_per_timestamp = {0: self.budget}
         self.total_capital_open_trades = {}
         self.lowest_total_capital_open_trades = {}
         self.highest_total_capital_open_trades = {}
-        self.realised_profits = []
         self.total_fee_paid = 0
 
     def tick(self, ohlcv: dict, data_dict: dict) -> None:
@@ -190,4 +190,4 @@ class TradingModule:
 
     def update_realised_profit(self, trade: Trade) -> None:
         self.realised_profit += trade.profit_dollar
-        self.realised_profits.append(self.realised_profit)
+        self.realised_profits_per_timestamp[int(datetime.timestamp(trade.closed_at)*1000)] = self.realised_profit

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -154,7 +154,9 @@ def test_multiple_periods_seen_drawdown_easy():
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
 
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_50_one_trade()
+
     fixture.frame_with_signals['COIN2/BASE'].test_scenario_down_50_one_trade()
+
     fixture.frame_with_signals['COIN3/BASE'].test_scenario_down_75_one_trade()
 
     # Act
@@ -171,7 +173,9 @@ def test_multiple_periods_seen_drawdown():
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
 
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
     fixture.frame_with_signals['COIN2/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
     fixture.frame_with_signals['COIN3/BASE'].test_scenario_up_100_down_20_down_75_three_trades()
 
     # Act
@@ -181,40 +185,37 @@ def test_multiple_periods_seen_drawdown():
     assert math.isclose(stats.main_results.max_seen_drawdown, -75.4975)
 
 
+def test_drawdown_equality():
+    """Given one coin, 'max seen/real drawdown' from main results should be equal
+    to that of the coin insights"""
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
 
-# def test_drawdown_equality():
-#     """Given one coin, 'max seen/real drawdown' from main results should be equal
-#     to that of the coin insights"""
-#     # Arrange
-#     fixture = StatsFixture(['COIN/BASE'])
-#
-#     fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_one_trade()
-#
-#     # Act
-#     stats = fixture.create().analyze()
-#
-#     # Assert
-#     assert stats.main_results.max_seen_drawdown == \
-#            stats.coin_res[0].max_seen_drawdown
-#     assert stats.main_results.max_realised_drawdown == \
-#            stats.coin_res[0].max_realised_drawdown
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_one_trade()
+
+    # Act
+    stats = fixture.create().analyze()
+
+    # Assert
+    assert math.isclose(stats.main_results.max_seen_drawdown, stats.coin_res[0].max_seen_drawdown)
+    assert math.isclose(stats.main_results.max_realised_drawdown, stats.coin_res[0].max_realised_drawdown)
 
 
-# def test_seen_drawdown_equals_realised_drawdown():
-#     """Given one coin, 'max seen drawdown' should be the
-#     lowest seen drawdown and 'max realised drawdown' should be the lowest
-#     actual realised drawdown"""
-#     # Arrange
-#     fixture = StatsFixture(['COIN/BASE'])
-#
-#     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_50_one_trade()
-#
-#     # Act
-#     stats = fixture.create().analyze()
-#
-#     # Assert
-#     assert stats.coin_res[0].max_seen_drawdown == \
-#            stats.coin_res[0].max_realised_drawdown
+def test_seen_drawdown_equals_realised_drawdown():
+    """Given one coin, 'max seen drawdown' should be the
+    lowest seen drawdown and 'max realised drawdown' should be the lowest
+    actual realised drawdown"""
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_50_one_trade()
+
+    # Act
+    stats = fixture.create().analyze()
+
+    # Assert
+    assert stats.coin_res[0].max_seen_drawdown == \
+           stats.coin_res[0].max_realised_drawdown
 
 
 def test_drawdown_simple():
@@ -231,7 +232,7 @@ def test_drawdown_simple():
 
     # Assert
     assert math.isclose(stats.coin_res[0].max_seen_drawdown, -80.2)
-    # assert math.isclose(stats.coin_res[0].max_realised_drawdown, -60.796)
+    assert math.isclose(stats.coin_res[0].max_realised_drawdown, -60.796)
 
 
 def test_drawdown_multiple_peaks():
@@ -247,35 +248,33 @@ def test_drawdown_multiple_peaks():
 
     # Assert
     assert math.isclose(stats.coin_res[0].max_seen_drawdown, -75.25)
-    # assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
+    assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
 
 
 def test_drawdown_multiple_pairs():
     """Given multiple pairs, 'max seen drawdown' should be the lowest seen drawdown
     of the different pairs combined"""
     # Arrange
-    # fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE'])
-    fixture = StatsFixture(['COIN/BASE'])
+    fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE'])
 
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
-    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_no_trades()
     fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_one_trade()
     #
-    # fixture.frame_with_signals['COIN2/BASE'].test_scenario_up_100_down_20_down_75_three_trades()
-    # fixture.frame_with_signals['COIN2/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+    fixture.frame_with_signals['COIN2/BASE'].test_scenario_up_100_down_20_down_75_three_trades()
+    fixture.frame_with_signals['COIN2/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
 
     # Act
     stats = fixture.create().analyze()
 
     # Assert
     assert math.isclose(stats.coin_res[0].max_seen_drawdown, -90.3940399)
-    # assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
+    assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
 
-    # assert math.isclose(stats.coin_res[1].max_seen_drawdown, -83.22282373767418)
-    # # assert math.isclose(stats.coin_res[1].max_realised_drawdown, -83.05335731078199)
-    #
-    # assert math.isclose(stats.main_results.max_seen_drawdown, -84.49838188862499)
-    # assert math.isclose(stats.main_results.max_realised_drawdown, -85.52890115608895)
+    assert math.isclose(stats.coin_res[1].max_seen_drawdown, -83.22282373767418)
+    assert math.isclose(stats.coin_res[1].max_realised_drawdown, -83.05335731078199)
+
+    assert math.isclose(stats.main_results.max_seen_drawdown, -84.49838188862499)
+    assert math.isclose(stats.main_results.max_realised_drawdown, -85.52890115608895)
 
 
 def test_seen_drawdown_up_down():

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -82,7 +82,7 @@ def test_multiple_periods_realized_drawdown():
     stats = fixture.create().analyze()
 
     # Assert
-    assert math.isclose(stats.main_results.max_realised_drawdown, -76.5727336801886)
+    assert math.isclose(stats.main_results.max_realised_drawdown, -75.4975)
 
 
 def test_simple_seen_drawdown():
@@ -248,7 +248,7 @@ def test_drawdown_multiple_peaks():
 
     # Assert
     assert math.isclose(stats.coin_res[0].max_seen_drawdown, -75.25)
-    assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
+    assert math.isclose(stats.coin_res[0].max_realised_drawdown, -55.8955)
 
 
 def test_drawdown_multiple_pairs():
@@ -258,6 +258,7 @@ def test_drawdown_multiple_pairs():
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE'])
 
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_flat_no_trades()
     fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_one_trade()
 
     fixture.frame_with_signals['COIN2/BASE'].test_scenario_up_100_down_20_down_75_three_trades()
@@ -270,11 +271,11 @@ def test_drawdown_multiple_pairs():
     assert math.isclose(stats.coin_res[0].max_seen_drawdown, -90.3940399)
     assert math.isclose(stats.coin_res[0].max_realised_drawdown, -90.3940399)
 
-    assert math.isclose(stats.coin_res[1].max_seen_drawdown, -83.22282373767418)
-    assert math.isclose(stats.coin_res[1].max_realised_drawdown, -83.05335731078199)
+    assert math.isclose(stats.coin_res[1].max_seen_drawdown, -91.86056132492075)
+    assert math.isclose(stats.coin_res[1].max_realised_drawdown, -91.86056132492075)
 
-    assert math.isclose(stats.main_results.max_seen_drawdown, -84.49838188862499)
-    assert math.isclose(stats.main_results.max_realised_drawdown, -85.52890115608895)
+    assert math.isclose(stats.main_results.max_seen_drawdown, -85.76400119125371)
+    assert math.isclose(stats.main_results.max_realised_drawdown, -85.76400119125371)
 
 
 def test_seen_drawdown_up_down():

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -276,6 +276,8 @@ def test_drawdown_multiple_pairs():
 
     assert math.isclose(stats.main_results.max_seen_drawdown, -85.76400119125371)
     assert math.isclose(stats.main_results.max_realised_drawdown, -85.76400119125371)
+    assert stats.main_results.n_trades_with_loss == 7
+    assert stats.main_results.n_consecutive_losses == 4
 
 
 def test_seen_drawdown_up_down():

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -215,8 +215,8 @@ def test_drawdown_equality():
     stats = fixture.create().analyze()
 
     # Assert
-    assert math.isclose(stats.main_results.max_seen_drawdown, stats.coin_res[0].max_seen_drawdown)
-    assert math.isclose(stats.main_results.max_realised_drawdown, stats.coin_res[0].max_realised_drawdown)
+    assert math.isclose(stats.main_results.max_seen_drawdown, stats.coin_results[0].max_seen_drawdown)
+    assert math.isclose(stats.main_results.max_realised_drawdown, stats.coin_results[0].max_realised_drawdown)
 
 
 def test_seen_drawdown_equals_realised_drawdown():
@@ -232,8 +232,8 @@ def test_seen_drawdown_equals_realised_drawdown():
     stats = fixture.create().analyze()
 
     # Assert
-    assert stats.coin_res[0].max_seen_drawdown == \
-           stats.coin_res[0].max_realised_drawdown
+    assert stats.coin_results[0].max_seen_drawdown == \
+           stats.coin_results[0].max_realised_drawdown
 
 
 def test_drawdown_simple():

--- a/test/stats/test_main_results.py
+++ b/test/stats/test_main_results.py
@@ -214,8 +214,10 @@ def test_n_trades():
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
 
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
     fixture.frame_with_signals['COIN2/BASE'].test_scenario_up_100_down_20_down_75_three_trades()
     fixture.frame_with_signals['COIN3/BASE'].test_scenario_down_75_one_trade()
+
     fixture.frame_with_signals['COIN3/BASE'].test_scenario_up_50_one_trade()
     fixture.frame_with_signals['COIN3/BASE'].test_scenario_up_100_one_trade_no_sell()
 

--- a/test/stats/test_main_results.py
+++ b/test/stats/test_main_results.py
@@ -247,6 +247,9 @@ def test_n_average_trades():
 
     # Assert
     assert stats.main_results.n_average_trades == 3.0
+    assert stats.main_results.n_left_open_trades == 0
+    assert stats.main_results.n_trades_with_loss == 2
+    assert stats.main_results.n_consecutive_losses == 1
 
 
 def test_n_average_trades_no_trades():
@@ -264,6 +267,9 @@ def test_n_average_trades_no_trades():
 
     # Assert
     assert stats.main_results.n_average_trades == 0
+    assert stats.main_results.n_left_open_trades == 0
+    assert stats.main_results.n_trades_with_loss == 0
+    assert stats.main_results.n_consecutive_losses == 0
 
 
 def test_n_average_trades_more_time_less_trades():


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Simplifies the max realised drawdown, and the nr of losing trades and consecutive losses. Added tests for all three.


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->


# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->


# Actions to be performed before this can be merged
<!-- Think of other PR's, scripts etc etc (delete te options which don't apply, and leave the checkbox open because it will be filled by the reviewer) -->
- [x] PR depends on #280 (simple seen drawdown)


# Security Measures
<!-- Which security measures did you take when developing? Think of exception handling, logging etc -->


# Potential Issues / Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->


# Assumptions made / Things to add to the wiki
<!-- Did you make any assumptions during this development? Certain flows or logic? This could be quite broad, but it's
 very crucial to avoid misconceptions regarding the working of the engine --> 

# Packages added
<!-- Did you add new packages to the code? What are the licences of the packages? Make sure to only add packages
 that are allowed to be used in the engine -->

# Additional Info
<!-- Write anything here that wasn't mentioned above -->
