### PR TITLE
add BTC and ETH as currencies

### DIFF
--- a/modules/setup/config/currencies.py
+++ b/modules/setup/config/currencies.py
@@ -14,6 +14,10 @@ def get_currency_symbol_from_code(currency_code: str) -> str:
         return "£"
     if "JPY" in currency_code:
         return "¥"
+    if "BTC" in currency_code:
+        return "BTC"
+    if "ETH" in currency_code:
+        return "ETH"
     else:
         print(
             "[WARNING] Could not find right symbol for your base currency, using $ instead")

--- a/modules/setup/config/specification.json
+++ b/modules/setup/config/specification.json
@@ -86,7 +86,7 @@
     "name": "currency",
     "default": "USDT",
     "type": "string",
-    "options": ["USDT"]
+    "options": ["USDT", "BTC", "ETH"]
   },
   {
     "name": "fee",


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Adds BTC and ETH as possible base currencies. Will show "BTC" or "ETH" respectively in results overview instead of currency symbol.