### PR TITLE
remove unneccesary @cache

### DIFF
--- a/cli/arg_parse.py
+++ b/cli/arg_parse.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import os
 from datetime import datetime
-from functools import cache
 from typing import TypedDict, Callable
 
 from utils.utils import get_project_root
@@ -15,7 +14,6 @@ CliActions = TypedDict("CliActions", {
 CLI_DESCR = "Dema Trading Engine"
 
 
-@cache
 def read_spec() -> list:
     spec_file_path = os.path.join(get_project_root(), "resources", "specification.json")
 


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Makes it once again possible to run the engine straight from python while using a python3 version that is not python 3.9

