### PR TITLE
Feat/add plots and trade log messages

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -7,6 +7,9 @@ from modules.stats.stats_config import StatsConfig
 from modules.stats.trade import SellReason
 from modules.stats.trading_stats import TradingStats
 
+FONT_BOLD = "\033[1m"
+FONT_RESET = "\033[0m"
+
 
 class OutputModule(object):
     config: StatsConfig
@@ -22,12 +25,12 @@ class OutputModule(object):
 
         show_trade_anomalies(stats)
 
-        print("[INFO] Logging trades to " + "\033[1m" + "data/backtesting-data/trades_log.json" + "\033[0m...")
+        print("[INFO] Logging trades to " + FONT_BOLD + "data/backtesting-data/trades_log.json" + FONT_RESET + "...")
         log_trades(stats)
 
         # plot graphs
         if self.config.plots:
-            print("[INFO] Creating plots in " + "\033[1m" + "data/backtesting-data/plots" + "\033[0m...")
+            print("[INFO] Creating plots in " + FONT_BOLD + "data/backtesting-data/plots" + FONT_RESET + "...")
             plot_per_coin(stats, config=self.config)
         print("[INFO] Backtest finished!")
 

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -22,8 +22,6 @@ class OutputModule(object):
 
         show_trade_anomalies(stats)
 
-        show_signature()
-
         print("[INFO] Logging trades to " + "\033[1m" + "data/backtesting-data/trades_log.json" + "\033[0m...")
         log_trades(stats)
 
@@ -32,6 +30,8 @@ class OutputModule(object):
             print("[INFO] Creating plots in " + "\033[1m" + "data/backtesting-data/plots" + "\033[0m...")
             plot_per_coin(stats, config=self.config)
         print("[INFO] Backtest finished!")
+
+        show_signature()
 
 
 def show_trade_anomalies(stats: TradingStats):

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -24,11 +24,14 @@ class OutputModule(object):
 
         show_signature()
 
+        print("[INFO] Logging trades to " + "\033[1m" + "data/backtesting-data/trades_log.json" + "\033[0m...")
         log_trades(stats)
 
         # plot graphs
         if self.config.plots:
+            print("[INFO] Creating plots in " + "\033[1m" + "data/backtesting-data/plots" + "\033[0m...")
             plot_per_coin(stats, config=self.config)
+        print("[INFO] Backtest finished!")
 
 
 def show_trade_anomalies(stats: TradingStats):

--- a/modules/output/plots.py
+++ b/modules/output/plots.py
@@ -9,18 +9,6 @@ from modules.stats.trading_stats import TradingStats
 
 
 def plot_sizes(subplot_indicator, df):
-    """
-    Method that calculates the amount of rows and height for the plot
-    :param subplot_indicator: list with indicators outside the price scale
-    :type subplot_indicator: list
-    :param df: dataframe
-    :type df: df
-    :return rows: amount of rows in the final plot
-    :rtype rows: int
-    :return height: height of all subplots
-    :rtype height: float
-    """
-
     rows = 1
     for ind in subplot_indicator:
         if ind in df.columns.values:
@@ -37,18 +25,6 @@ def plot_sizes(subplot_indicator, df):
 
 
 def add_buy_sell_signal(fig, df, dates):
-    """
-    Method that lists buy or sell signals over time
-    :param fig: Ongoing plot
-    :type fig: plotly figure
-    :param dates: points in time
-    :type dates: list
-    :param df: dataframe
-    :type df: df
-    :return: figure with added buy and sell signals
-    :rtype: fig
-    """
-
     buy_signals = df["buy"] * df["close"]
     sell_signals = df["sell"] * df["close"]
 
@@ -64,24 +40,6 @@ def add_buy_sell_signal(fig, df, dates):
 
 
 def add_buy_sell_points(fig, pair, dates, df, buypoints, sellpoints):
-    """
-    Method that lists buy or sell points over time
-    :param fig: Ongoing plot
-    :type fig: plotly figure
-    :param pair: pair of coins
-    :type pair: str
-    :param dates: points in time
-    :type dates: list
-    :param df: dataframe
-    :type df: df
-    :param buypoints: buy points in time
-    :type buypoints: dict
-    :param sellpoints: sell points in time
-    :type sellpoints: dict
-    :return: figure with added buy and sell points
-    :rtype: fig
-    """
-
     buy_points_value = []
     sell_points_value = []
     for x in range(len(dates)):
@@ -113,22 +71,6 @@ def add_buy_sell_points(fig, pair, dates, df, buypoints, sellpoints):
 
 
 def add_indicators(fig, dates, df, mainplot_indicators, subplot_indicators):
-    """
-    Method that adds indicators to plot
-    :param fig: Ongoing plot
-    :type fig: plotly figure
-    :param dates: points in time
-    :type dates: list
-    :param df: dataframe
-    :type df: df
-    :param mainplot_indicators: list with indicators on the price scale
-    :type mainplot_indicators: list
-    :param subplot_indicators: list with indicators outside the price scale
-    :type subplot_indicators: list
-    :return: figure with added buy and sell signals
-    :rtype: fig
-    """
-
     # add mainplot_indicator
     for ind in mainplot_indicators:
         if ind in df.columns.values:
@@ -151,12 +93,6 @@ def add_indicators(fig, dates, df, mainplot_indicators, subplot_indicators):
 
 
 def plot_per_coin(stats: TradingStats, config: StatsConfig):
-    """
-    Plot dataframe of a all coin pairs
-    :return: None
-    :rtype: None
-    """
-
     for pair in stats.df.keys():
 
         # create figure


### PR DESCRIPTION
# Results of merging this
Shows a message underneath backtesting results:
- trades are being logged, and location of trade log
- if plots is set to true: plots are being plotted, and location of them
- end of backtest

![image](https://user-images.githubusercontent.com/14127457/123797077-1c12bd80-d8e6-11eb-9c1c-7d149e304b3a.png)


I decided to show the logs after the backtesting result, because the location of the plots and trade logs were also included, and showing them underneath the backtesting result makes it really visible. This way, everyone will be aware that there are plots and logs, and where they are!