### PR TITLE
Update build_executables_mac.yml

### DIFF
--- a/.github/workflows/build_executables_mac.yml
+++ b/.github/workflows/build_executables_mac.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           name: engine-macos
       - name: build archive
-        run: zip -j engine ./engine.exe
+        run: zip -j engine ./engine
       - run: ls -la
       - run: |
           aws s3 --endpoint=https://ams3.digitaloceanspaces.com cp ./engine.zip s3://engine-store/engine-macos-${GITHUB_REF##*/}.zip --acl "public-read"


### PR DESCRIPTION
# Results of merging this
Executable deploy pipeline for MacOS was failing because it was referencing the wrong file. This should fix that 
