### PR TITLE
Removed running on push to save some runner resources

### DIFF
--- a/.github/workflows/PR-Push-test.yml
+++ b/.github/workflows/PR-Push-test.yml
@@ -1,10 +1,7 @@
 name: Test PR/Push
 on:
-  push:
-    branches: [feature/**, fix/**, development]
   pull_request:
-    branches: [development]
-   
+    branches: [development, main]
 jobs:
   pytest-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Results of merging this
Since both `development` & `main` are protected, there should be no possibility for lint errors to sneak in. Not running on every push saves us some runner resources