### PR TITLE
Feat/drawdown metric per coin

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "60": 4,
     "120": 3
   },
-  "pairs": ["BTC/USDT", "LTC/USDT", "ETH/USDT"],
+  "pairs": ["LTC/USDT", "ETH/USDT"],
   "currency": "USDT",
   "fee": 0.25,
   "strategy-name": "MyStrategy",

--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "60": 4,
     "120": 3
   },
-  "pairs": ["LTC/USDT", "ETH/USDT"],
+  "pairs": ["BTC/USDT", "LTC/USDT", "ETH/USDT"],
   "currency": "USDT",
   "fee": 0.25,
   "strategy-name": "MyStrategy",

--- a/main_controller.py
+++ b/main_controller.py
@@ -10,7 +10,8 @@ from modules.stats.tradingmodule_config import create_trading_module_config
 
 class MainController:
 
-    async def run(self, args) -> None:
+    @staticmethod
+    async def run(args) -> None:
         async with create_config_module(args) as config:
             data_module = await DataModule.create(config)
             setup_module = SetupModule(config, data_module)
@@ -18,7 +19,9 @@ class MainController:
             algo_module = await setup_module.setup()
             df, dict_with_signals = algo_module.run()
 
-            stats_config = to_stats_config(config, await data_module.load_btc_marketchange())
+            stats_config = to_stats_config(config,
+                                           await data_module.load_btc_marketchange(),
+                                           await data_module.load_btc_drawdown(df))
 
             trading_module_config = create_trading_module_config(config)
             trading_module = TradingModule(trading_module_config)

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -52,6 +52,7 @@ class MainResults:
     max_open_trades: int
     market_change_coins: float
     market_change_btc: float
+    market_drawdown_btc: float
     starting_capital: float
     end_capital: float
     overall_profit_percentage: float
@@ -176,6 +177,9 @@ class MainResults:
         performance_table.add_row('Market change BTC',
                                   colorize(round(self.market_change_btc,
                                                  2), 0, '%'))
+        performance_table.add_row('Market drawdown BTC',
+                                  colorize(round(self.market_drawdown_btc,
+                                                 2), 0, '%'))
         performance_table.add_row('Total fee paid',
                                   f"{round(self.total_fee_amount)} {currency_symbol}")
         return performance_table
@@ -209,6 +213,7 @@ class CoinInsights:
     profit: float
     n_trades: int
     market_change: float
+    market_drawdown: float
     max_seen_drawdown: float
     max_realised_drawdown: float
     avg_trade_duration: timedelta
@@ -242,6 +247,7 @@ class CoinInsights:
 
             coin_metrics_table.add_row(c.pair,
                                        colorize(round(c.market_change, 2), 0),
+                                       colorize(round(c.market_drawdown, 2), 0),
                                        colorize(round(c.max_seen_drawdown, 2), 0),
                                        colorize(round(c.max_realised_drawdown, 2), 0),
                                        )
@@ -281,6 +287,7 @@ class CoinInsights:
         coin_metrics_table = Table(title="Coin Metrics", box=box.ROUNDED, width=100)
         coin_metrics_table.add_column("Pair", justify=justification)
         coin_metrics_table.add_column("Market change (%)", justify=justification)
+        coin_metrics_table.add_column("Market drawdown (%)", justify=justification)
         coin_metrics_table.add_column("Max. seen drawdown (%)", justify=justification)
         coin_metrics_table.add_column("Max. realised drawdown (%)",
                                       justify=justification)

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -49,6 +49,7 @@ class MainResults:
     tested_to: datetime
     max_open_trades: int
     market_change_coins: float
+    market_drawdown_coins: float
     market_change_btc: float
     market_drawdown_btc: float
     starting_capital: float
@@ -171,6 +172,9 @@ class MainResults:
         performance_table.add_row('Max. seen drawdown at', drawdown_at_string)
         performance_table.add_row('Market change coins',
                                   colorize(round(self.market_change_coins,
+                                                 2), 0, '%'))
+        performance_table.add_row('Market drawdown coins',
+                                  colorize(round(self.market_drawdown_coins,
                                                  2), 0, '%'))
         performance_table.add_row('Market change BTC',
                                   colorize(round(self.market_change_btc,

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -173,11 +173,11 @@ class MainResults:
         performance_table.add_row('Market change coins',
                                   colorize(round(self.market_change_coins,
                                                  2), 0, '%'))
-        performance_table.add_row('Market drawdown coins',
-                                  colorize(round(self.market_drawdown_coins,
-                                                 2), 0, '%'))
         performance_table.add_row('Market change BTC',
                                   colorize(round(self.market_change_btc,
+                                                 2), 0, '%'))
+        performance_table.add_row('Market drawdown coins',
+                                  colorize(round(self.market_drawdown_coins,
                                                  2), 0, '%'))
         performance_table.add_row('Market drawdown BTC',
                                   colorize(round(self.market_drawdown_btc,

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -29,6 +29,9 @@ class ConfigModule(object):
     timeframe: str
     timeframe_ms: int
 
+    def __init__(self):
+        self.exchange = None
+
     @staticmethod
     async def create(args):
         config_module = ConfigModule()

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -30,6 +30,18 @@ class ConfigModule(object):
     timeframe_ms: int
 
     def __init__(self):
+        self.subplot_indicators = None
+        self.mainplot_indicators = None
+        self.currency_symbol = None
+        self.starting_capital = None
+        self.plots = None
+        self.backtesting_from = None
+        self.backtesting_to = None
+        self.max_open_trades = None
+        self.stoploss_type = None
+        self.stoploss = None
+        self.fee = None
+        self.strategy_definition = None
         self.exchange = None
 
     @staticmethod

--- a/modules/setup/datamodule.py
+++ b/modules/setup/datamodule.py
@@ -13,6 +13,7 @@ from cli.print_utils import print_info, print_error, print_warning
 
 # Files
 from modules.setup.config import ConfigModule
+from modules.stats.drawdown.drawdown import get_max_drawdown_ratio
 from utils.utils import get_ohlcv_indicators
 
 # ======================================================================
@@ -54,6 +55,19 @@ class DataModule:
         begin_close_value = begin_data[0][4]
         end_close_value = end_data[0][4]
         return end_close_value / begin_close_value
+
+    async def load_btc_drawdown(self, df: dict):
+        print_info("Fetching market drawdown of BTC/USDT...")
+
+        if 'BTC/USDT' in df.keys():
+            bitcoin_df = df.get('BTC/USDT')
+        else:
+            bitcoin_data = await self.get_pair_data('BTC/USDT')
+            bitcoin_df = bitcoin_data[1]
+        bitcoin_values = bitcoin_df[['close']].rename(columns={'close': 'value'})
+
+        bitcoin_drawdown = get_max_drawdown_ratio(bitcoin_values)
+        return bitcoin_drawdown
 
     async def load_historical_data(self) -> dict:
         dataframes = await asyncio.gather(*[self.get_pair_data(pair) for pair in self.config.pairs])

--- a/modules/setup/datamodule.py
+++ b/modules/setup/datamodule.py
@@ -62,8 +62,7 @@ class DataModule:
         if 'BTC/USDT' in df.keys():
             bitcoin_df = df.get('BTC/USDT')
         else:
-            bitcoin_data = await self.get_pair_data('BTC/USDT')
-            bitcoin_df = bitcoin_data[1]
+            pair, bitcoin_df = await self.get_pair_data('BTC/USDT')
         bitcoin_values = bitcoin_df[['close']].rename(columns={'close': 'value'})
 
         bitcoin_drawdown = get_max_drawdown_ratio(bitcoin_values)

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta
+
+from pandas import DataFrame
 from tqdm import tqdm
 import numpy as np
 
 from modules.output.results import CoinInsights, MainResults, LeftOpenTradeResult
 from modules.pairs_data import PairsData
+from modules.stats.drawdown.drawdown import get_max_drawdown_ratio
 from modules.stats.drawdown.per_coin import get_max_seen_drawdown_per_coin, get_max_realised_drawdown_per_coin
 from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portfolio, \
     get_max_realised_drawdown_for_portfolio
@@ -66,6 +69,19 @@ def calculate_trade_durations(closed_trades):
     return avg_trade_duration, longest_trade_duration, shortest_trade_duration
 
 
+def get_market_drawdown(pairs: list, data_dict: dict) -> dict:
+    market_drawdown = {}
+    total_drawdown = 0
+    for pair in pairs:
+        values_list = [data_dict[pair][d].get('close') for d in data_dict[pair]]
+        coin_values = DataFrame(values_list, columns=['value'])
+        coin_drawdown = get_max_drawdown_ratio(coin_values)
+        market_drawdown[pair] = coin_drawdown
+        total_drawdown += coin_drawdown
+    market_drawdown['all'] = total_drawdown / len(pairs) if len(pairs) > 0 else 1
+    return market_drawdown
+
+
 class StatsModule:
     buy_points = None
     sell_points = None
@@ -87,14 +103,14 @@ class StatsModule:
                 self.trading_module.tick(tick_dict, pair_dict)
 
         market_change = get_market_change(ticks, pairs, self.frame_with_signals)
-        return self.generate_backtesting_result(market_change)
+        market_drawdown = get_market_drawdown(pairs, self.frame_with_signals)
+        return self.generate_backtesting_result(market_change, market_drawdown)
 
-    def generate_backtesting_result(self,
-                                    market_change: dict) -> TradingStats:
+    def generate_backtesting_result(self, market_change: dict, market_drawdown: dict) -> TradingStats:
 
         trading_module = self.trading_module
 
-        coin_results = self.generate_coin_results(trading_module.closed_trades, market_change)
+        coin_results = self.generate_coin_results(trading_module.closed_trades, market_change, market_drawdown)
         best_trade_ratio, best_trade_pair, worst_trade_ratio, worst_trade_pair = \
             calculate_best_worst_trade(trading_module.closed_trades)
         open_trade_results = self.get_left_open_trades_results(trading_module.open_trades)
@@ -104,6 +120,7 @@ class StatsModule:
             trading_module.closed_trades,
             trading_module.budget,
             market_change,
+            0,
             best_trade_ratio,
             best_trade_pair,
             worst_trade_ratio,
@@ -122,7 +139,7 @@ class StatsModule:
         )
 
     def generate_main_results(self, open_trades: [Trade], closed_trades: [Trade], budget: float,
-                              market_change: dict, best_trade_ratio: float,
+                              market_change: dict, market_drawdown: float, best_trade_ratio: float,
                               best_trade_pair: str, worst_trade_ratio: float,
                               worst_trade_pair: str) -> MainResults:
         # Get total budget and calculate overall profit
@@ -158,6 +175,7 @@ class StatsModule:
                            max_open_trades=self.config.max_open_trades,
                            market_change_coins=(market_change['all'] - 1) * 100,
                            market_change_btc=(self.config.btc_marketchange_ratio - 1) * 100,
+                           market_drawdown_btc=market_drawdown,
                            starting_capital=self.config.starting_capital,
                            end_capital=budget,
                            overall_profit_percentage=overall_profit_percentage,
@@ -183,7 +201,7 @@ class StatsModule:
                            fee=self.config.fee,
                            total_fee_amount=self.trading_module.total_fee_paid)
 
-    def generate_coin_results(self, closed_trades: [Trade], market_change: dict) -> [list, dict]:
+    def generate_coin_results(self, closed_trades: [Trade], market_change: dict, market_drawdown: dict) -> [list, dict]:
         stats = self.calculate_statistics_per_coin(closed_trades)
         new_stats = []
 
@@ -194,6 +212,7 @@ class StatsModule:
             coin_insight = CoinInsights(pair=coin,
                                         n_trades=stats[coin]['amount_of_trades'],
                                         market_change=(market_change[coin] - 1) * 100,
+                                        market_drawdown=(market_drawdown[coin] - 1) * 100,
                                         cum_profit_percentage=stats[coin]['cum_profit_prct'],
                                         total_profit_percentage=(stats[coin]['total_profit_ratio'] - 1) * 100,
                                         avg_profit_percentage=avg_profit_prct,

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -71,14 +71,14 @@ def calculate_trade_durations(closed_trades):
 
 def get_market_drawdown(pairs: list, data_dict: dict) -> dict:
     market_drawdown = {}
-    total_drawdown = [0] * len(data_dict[pairs[0]])
+    pairs_profit_ratios_sum = [0] * len(data_dict[pairs[0]])
     for pair in pairs:
         values_list = [data_dict[pair][d].get('close') for d in data_dict[pair]]
-        coin_values = DataFrame(values_list, columns=['value'])
-        market_drawdown[pair] = get_max_drawdown_ratio(coin_values)
-        values_list = [x / values_list[0] for x in values_list]
-        total_drawdown = map(lambda x, y: x + y, total_drawdown, values_list)
-    market_drawdown['all'] = get_max_drawdown_ratio(DataFrame(total_drawdown, columns=['value']))
+        close_prices_df = DataFrame(values_list, columns=['value'])
+        market_drawdown[pair] = get_max_drawdown_ratio(close_prices_df)
+        profit_ratios = [x / values_list[0] for x in values_list]
+        pairs_profit_ratios_sum = map(lambda x, y: x + y, pairs_profit_ratios_sum, profit_ratios)
+    market_drawdown['all'] = get_max_drawdown_ratio(DataFrame(pairs_profit_ratios_sum, columns=['value']))
     return market_drawdown
 
 

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -120,7 +120,7 @@ class StatsModule:
             trading_module.closed_trades,
             trading_module.budget,
             market_change,
-            0,
+            market_drawdown,
             best_trade_ratio,
             best_trade_pair,
             worst_trade_ratio,
@@ -139,7 +139,7 @@ class StatsModule:
         )
 
     def generate_main_results(self, open_trades: [Trade], closed_trades: [Trade], budget: float,
-                              market_change: dict, market_drawdown: float, best_trade_ratio: float,
+                              market_change: dict, market_drawdown: dict, best_trade_ratio: float,
                               best_trade_pair: str, worst_trade_ratio: float,
                               worst_trade_pair: str) -> MainResults:
         # Get total budget and calculate overall profit
@@ -174,8 +174,9 @@ class StatsModule:
                            tested_to=tested_to,
                            max_open_trades=self.config.max_open_trades,
                            market_change_coins=(market_change['all'] - 1) * 100,
+                           market_drawdown_coins=(market_drawdown['all'] - 1) * 100,
                            market_change_btc=(self.config.btc_marketchange_ratio - 1) * 100,
-                           market_drawdown_btc=market_drawdown,
+                           market_drawdown_btc=(self.config.btc_drawdown_ratio - 1) * 100,
                            starting_capital=self.config.starting_capital,
                            end_capital=budget,
                            overall_profit_percentage=overall_profit_percentage,

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -71,14 +71,14 @@ def calculate_trade_durations(closed_trades):
 
 def get_market_drawdown(pairs: list, data_dict: dict) -> dict:
     market_drawdown = {}
-    total_drawdown = 0
+    total_drawdown = [0] * len(data_dict[pairs[0]])
     for pair in pairs:
         values_list = [data_dict[pair][d].get('close') for d in data_dict[pair]]
         coin_values = DataFrame(values_list, columns=['value'])
-        coin_drawdown = get_max_drawdown_ratio(coin_values)
-        market_drawdown[pair] = coin_drawdown
-        total_drawdown += coin_drawdown
-    market_drawdown['all'] = total_drawdown / len(pairs) if len(pairs) > 0 else 1
+        market_drawdown[pair] = get_max_drawdown_ratio(coin_values)
+        values_list = [x / values_list[0] for x in values_list]
+        total_drawdown = map(lambda x, y: x + y, total_drawdown, values_list)
+    market_drawdown['all'] = get_max_drawdown_ratio(DataFrame(total_drawdown, columns=['value']))
     return market_drawdown
 
 

--- a/modules/stats/stats_config.py
+++ b/modules/stats/stats_config.py
@@ -13,6 +13,7 @@ class StatsConfig:
     stoploss_type: str
     max_open_trades: int
     btc_marketchange_ratio: float
+    btc_drawdown_ratio: float
     backtesting_to: int
     backtesting_from: int
     plots: bool
@@ -20,13 +21,14 @@ class StatsConfig:
     currency_symbol: Literal["USDT"]
 
 
-def to_stats_config(config: ConfigModule, btc_marketchange_ratio: float):
+def to_stats_config(config: ConfigModule, btc_marketchange_ratio: float, btc_drawdown_ratio: float):
     return StatsConfig(
         fee=config.fee,
         stoploss=config.stoploss,
         stoploss_type=config.stoploss_type,
         max_open_trades=config.max_open_trades,
         btc_marketchange_ratio=btc_marketchange_ratio,
+        btc_drawdown_ratio=btc_drawdown_ratio,
         backtesting_to=config.backtesting_to,
         backtesting_from=config.backtesting_from,
         plots=config.plots,

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -27,6 +27,7 @@ class StatsFixture:
             backtesting_from=1,
             backtesting_to=10,
             btc_marketchange_ratio=1,
+            btc_drawdown_ratio=1,
             fee=FEE_PERCENTAGE,
 
             stoploss=STOPLOSS,


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes #274


# What has been changed?
BTC, coin, and market seen drawdown is added in the statistics. When BTC is present in the pairs, the pair data is used; if BTC is not present in the pairs, BTC's data is downloaded separately.
