### PR TITLE
Fix/change df index to int

### DIFF
--- a/modules/output/plots.py
+++ b/modules/output/plots.py
@@ -54,9 +54,9 @@ def add_buy_sell_points(fig, pair, dates, df, buypoints, sellpoints):
     close_ = df[pair]["close"]
     for x, date in enumerate(dates):
         if date in buypoints[pair]:
-            buy_points_value[x] = close_[x]
+            buy_points_value[x] = close_.iloc[x]
         if date in sellpoints[pair]:
-            sell_points_value[x] = close_[x]
+            sell_points_value[x] = close_.iloc[x]
 
     fig.add_trace((go.Scattergl(x=dates, y=buy_points_value,
                                 mode='markers',

--- a/modules/setup/datamodule.py
+++ b/modules/setup/datamodule.py
@@ -181,10 +181,10 @@ class DataModule:
 
         # Return correct backtesting period
         df = await self.check_backtesting_period(pair, df, final_timestamp)
-        begin_index = df.index.get_loc(self.config.backtesting_from)
-        end_index = df.index.get_loc(final_timestamp)
-        self.save_dataframe(pair, df)
         df.index = df.index.map(str)
+        begin_index = df.index.get_loc(str(self.config.backtesting_from))
+        end_index = df.index.get_loc(str(final_timestamp))
+        self.save_dataframe(pair, df)
 
         df = df[begin_index:end_index + 1]
         return df

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -46,25 +46,6 @@ def calculate_worth_of_open_trades(open_trades: [Trade]) -> float:
     return return_value
 
 
-def df_to_dict(df: DataFrame) -> dict:
-    """
-    Method turns dataframe into dictionary
-    """
-    df.index = df.index.map(str)
-    return df.to_dict('index')
-
-
-def str_to_df(data: str) -> DataFrame:
-    """
-    Method turns dictionary into dataframe
-    """
-    indicators = get_ohlcv_indicators()
-    json_file = rapidjson.loads(data)
-    df = pd.DataFrame.from_dict(json_file, orient='index', columns=indicators)
-    df.index = df.index.map(int)
-    return df
-
-
 def get_plot_indicators(config: dict):
     config.setdefault("mainplot_indicators", ['ema5', 'ema21'])
     config.setdefault("subplot_indicators", ['volume'])


### PR DESCRIPTION
Follow-up on #329 

# What has been changed?
Changed df index from `str` to `int`. 

FYI: `numeric` indexed series `[]` acts like `.loc[]` not `.iloc[]`, hence the explicit `.iloc[]` in `plots.py`

# Actions to be performed before this can be merged
- [ ] PR depends on #329 

