### PR TITLE
Fix results color

### DIFF
--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -92,7 +92,7 @@ def create_trade_info_table(self, justification) -> Table:
     trade_info_table.add_column("Trade Info "
                                 ":mag:",
                                 justify=justification,
-                                style="magenta")
+                                style="white")
     trade_info_table.add_column(justify=justification)
     trade_info_table.add_row('Amount of trades', str(self.n_trades))
     trade_info_table.add_row('Avg. trades per day',
@@ -122,7 +122,7 @@ def create_performance_table(self, currency_symbol, drawdown_at_string, drawdown
     performance_table = Table(box=box.ROUNDED)
     performance_table.add_column("Performance "
                                  ":chart_with_upwards_trend:", justify=justification,
-                                 style="cyan", width=25)
+                                 style="white", width=25)
     performance_table.add_column(justify=justification, width=20)
     performance_table.add_row('End capital',
                               colorize(round(self.end_capital, 2),


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
* Changes color of 'performance' and 'trade info' table to white

# Examples
<!-- Show some before and after examples. Could e.g. be screenshots, prints, logs etc etc -->
Fixes unreadable trade info results in Windows Powershell:
![image](https://user-images.githubusercontent.com/44836798/126140407-49b5f592-3156-4a1e-a015-6a539026137b.png)

