### PR TITLE
Fix/coin insight drawdowns

### DIFF
--- a/modules/stats/drawdown/drawdown.py
+++ b/modules/stats/drawdown/drawdown.py
@@ -9,6 +9,15 @@ def get_max_drawdown_ratio(df: pd.DataFrame):
     return df["drawdown_ratio"].min()
 
 
+def get_max_drawdown_ratio_without_buy_rows(df: pd.DataFrame):
+    """
+    @param df: with column["value"]
+    """
+    df["drawdown_ratio"] = df["value"] / df["value"].cummax()
+    ans = df.loc[df['buy'] == 0.0]["drawdown_ratio"].min()
+    return ans
+
+
 def get_max_drawdown_ratio_series(series: pd.Series):
     series = series / series.cummax()
     return series.min()

--- a/modules/stats/metrics/profit_ratio.py
+++ b/modules/stats/metrics/profit_ratio.py
@@ -49,6 +49,7 @@ def map_trades_to_opened_closed_timestamps(closed_pair_trades):
 
 
 def apply_profit_ratio(df, trades_open_closed):
+    df["corrected_close"] = df["corrected_close"].fillna(None, 'ffill')
     for open_timestamp, close in trades_open_closed:
         # skip the first row of each trade
         idx = np.searchsorted(df.index, open_timestamp)

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from tqdm import tqdm
 import numpy as np
 from collections import defaultdict
 
@@ -8,7 +7,7 @@ from cli.print_utils import print_info
 from modules.output.results import CoinInsights, MainResults, LeftOpenTradeResult
 from modules.public.pairs_data import PairsData
 from modules.public.trading_stats import TradingStats
-from modules.stats.drawdown.drawdown import get_max_drawdown_ratio
+from modules.stats.drawdown.drawdown import get_max_drawdown_ratio, get_max_drawdown_ratio_without_buy_rows
 from modules.stats.metrics.profit_ratio import get_seen_cum_profit_ratio_per_coin, get_realised_profit_ratio
 from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portfolio, \
     get_max_realised_drawdown_for_portfolio
@@ -95,6 +94,7 @@ class StatsModule:
         max_realised_drawdown = get_max_realised_drawdown_for_portfolio(
             self.trading_module.realised_profits_per_timestamp
         )
+
         max_seen_drawdown = get_max_seen_drawdown_for_portfolio(
             self.trading_module.capital_per_timestamp
         )
@@ -231,7 +231,7 @@ class StatsModule:
                 self.config.fee,
             )
             per_coin_stats[key]["max_realised_ratio"] = \
-                get_max_drawdown_ratio(realised_cum_profit_ratio_df)
+                get_max_drawdown_ratio_without_buy_rows(realised_cum_profit_ratio_df)
 
             # Find avg, longest and shortest trade durations
             per_coin_stats[key]["avg_trade_duration"], \

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -309,6 +309,42 @@ def test_drawdown_multiple_pairs():
     assert stats.main_results.n_consecutive_losses == 4
 
 
+def test_drawdown_with_stoploss_one_trade():
+    """Given stoploss hit, coin insight drawdown should be correct"""
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_one_trade()
+
+    fixture.trading_module_config.stoploss = -50
+    fixture.stats_config.stoploss = -50
+
+    # Act
+    stats = fixture.create().analyze()
+
+    # Assert
+    assert math.isclose(stats.coin_results[0].max_seen_drawdown, -72.2222222222)
+    assert math.isclose(stats.coin_results[0].max_realised_drawdown, -50.5)
+
+
+def test_drawdown_with_stoploss_multiple_trades():
+    """Given stoploss hit, coin insight drawdown should be correct"""
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
+    fixture.trading_module_config.stoploss = -50
+    fixture.stats_config.stoploss = -50
+
+    # Act
+    stats = fixture.create().analyze()
+
+    # Assert
+    assert math.isclose(stats.coin_results[0].max_seen_drawdown, -50.5)
+    assert math.isclose(stats.coin_results[0].max_realised_drawdown, -50.5)
+
+
 def test_seen_drawdown_up_down():
     """Given 'one trade', 'seen_drawdown' should 'reflect actual'"""
     # Arrange


### PR DESCRIPTION
# Results of merging this
Fixes multiple bugs related to max seen drawdown and max realised drawdown in coin insights.

Max seen drawdown:
- The stoploss and ROI prices weren't taken into account
- When missing rows, the profit ratio would be wrong for the first new row, which resulted in a minor difference in seen drawdown

Max realised drawdown:
- The buy price was also taken into account, which it shouldn't be.

Additionally to fixing these bugs, two new tests have been implemented to check the relation between stoploss and coin drawdown.