### PR TITLE
Fixed trades log and tearsheet bugs

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -68,7 +68,7 @@ def show_trade_anomalies(stats: TradingStats):
 
 def log_trades(stats: TradingStats):
     trades_dict = {}
-    for trade in stats.trades:
+    for i, trade in enumerate(stats.trades):
         trade_dict = {'status': trade.status,
                       'opened_at': trade.opened_at,
                       'closed_at': trade.closed_at,
@@ -81,7 +81,7 @@ def log_trades(stats: TradingStats):
                       'currency_amount': trade.currency_amount,
                       'sell_reason': trade.sell_reason}
 
-        trades_dict[str(trade.opened_at)] = trade_dict
+        trades_dict[i] = trade_dict
 
     trades_dict = dict(sorted(trades_dict.items()))
 
@@ -93,7 +93,7 @@ def log_trades(stats: TradingStats):
 def create_tearsheet(trades):
     dict_count = len(trades)
     df = pd.DataFrame(trades[0].__dict__, index=[0])
-    for i in range(1,dict_count-1):
+    for i in range(1, dict_count):
         df = df.append(trades[i].__dict__, ignore_index=True)
 
     df.to_excel('data/backtesting-data/tearsheet.xlsx')


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
* Fixed bug in trades log where trades opened on the same timestamp where not all logged (since 'opened at' was used as key')
* Fixed tearsheet bug where the last trade entry was nog included