### PR TITLE
added json export of main results

### DIFF
--- a/backtest_runner.py
+++ b/backtest_runner.py
@@ -33,7 +33,7 @@ class BacktestRunner:
 
     def run_outputted_backtest(self):
         stats = self.run_backtest()
-        OutputModule(self.stats_config).output(stats)
+        OutputModule(self.stats_config).output(stats, self.module.strategy_definition)
 
 
 @asynccontextmanager

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "exchange": "binance",
-  "timeframe": "5m",
+  "timeframe": "1h",
   "max-open-trades": 3,
   "exposure-per-trade": 100,
   "starting-capital": 1000,
@@ -19,8 +19,9 @@
   "fee": 0.25,
   "strategy-name": "MyStrategy",
   "strategies-folder": "resources/setup/strategies",
-  "plots": true,
+  "plots": false,
   "tearsheet": false,
+  "export_result": true,
   "mainplot_indicators": ["ema5", "ema21"],
   "subplot_indicators": [["volume"]]
 }

--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
   "strategies-folder": "resources/setup/strategies",
   "plots": true,
   "tearsheet": false,
-  "export_result": true,
+  "export-result": false,
   "mainplot_indicators": ["ema5", "ema21"],
   "subplot_indicators": [["volume"]]
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "exchange": "binance",
-  "timeframe": "1h",
+  "timeframe": "5m",
   "max-open-trades": 3,
   "exposure-per-trade": 100,
   "starting-capital": 1000,
@@ -19,7 +19,7 @@
   "fee": 0.25,
   "strategy-name": "MyStrategy",
   "strategies-folder": "resources/setup/strategies",
-  "plots": false,
+  "plots": true,
   "tearsheet": false,
   "export_result": true,
   "mainplot_indicators": ["ema5", "ema21"],

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import os
 import pandas as pd
@@ -52,6 +53,11 @@ class OutputModule(object):
             equity_plot(stats.capital_per_timestamp)
         print_info("Backtest finished!")
 
+        # Export backtest result as JSON
+        if self.config.export_result:
+            print_info("Exporting backtest report to " + FONT_BOLD + "data/backtesting-data/backtest_result.json" + FONT_RESET + "...")
+            export_backtest_result(stats)
+
         show_signature()
 
 
@@ -88,6 +94,7 @@ def log_trades(stats: TradingStats):
     with open('./data/backtesting-data/trades_log.json', 'w', encoding='utf-8') as f:
         f.write(trades_json)
 
+
 def create_tearsheet(trades):
     dict_count = len(trades)
     df = pd.DataFrame(trades[0].__dict__, index=[0])
@@ -95,3 +102,8 @@ def create_tearsheet(trades):
         df = df.append(trades[i].__dict__, ignore_index=True)
 
     df.to_excel('data/backtesting-data/tearsheet.xlsx')
+
+
+def export_backtest_result(stats):
+    with open("data/backtesting-data/backtest_result.json", 'w') as f:
+        json.dump(dataclasses.asdict(stats.main_results), default=str, fp=f)

--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -10,6 +10,7 @@ from modules.output.results import show_signature, CoinInsights, LeftOpenTradeRe
 from modules.public.trading_stats import TradingStats
 from modules.stats.stats_config import StatsConfig
 from modules.stats.trade import SellReason
+from modules.setup.config.strategy_definition import StrategyDefinition
 
 FONT_BOLD = "\033[1m"
 FONT_RESET = "\033[0m"
@@ -21,7 +22,7 @@ class OutputModule(object):
     def __init__(self, config: StatsConfig):
         self.config = config
 
-    def output(self, stats: TradingStats):
+    def output(self, stats: TradingStats, strategy_definition: StrategyDefinition):
         # print tables
         show_mainresults(stats.main_results, self.config.currency_symbol)
         CoinInsights.show(stats.coin_results, self.config.currency_symbol)
@@ -56,7 +57,7 @@ class OutputModule(object):
         # Export backtest result as JSON
         if self.config.export_result:
             print_info("Exporting backtest report to " + FONT_BOLD + "data/backtesting-data/backtest_result.json" + FONT_RESET + "...")
-            export_backtest_result(stats)
+            export_backtest_result(stats, strategy_definition)
 
         show_signature()
 
@@ -104,6 +105,6 @@ def create_tearsheet(trades):
     df.to_excel('data/backtesting-data/tearsheet.xlsx')
 
 
-def export_backtest_result(stats):
-    with open("data/backtesting-data/backtest_result.json", 'w') as f:
+def export_backtest_result(stats, strategy_definition):
+    with open(f"data/backtesting-data/{strategy_definition.strategy_name}_backtest_result.json", 'w') as f:
         json.dump(dataclasses.asdict(stats.main_results), default=str, fp=f)

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -33,6 +33,7 @@ class ConfigModule(object):
         self.starting_capital = None
         self.plots = None
         self.tearsheet = None
+        self.export_result = None
         self.backtesting_from = None
         self.backtesting_to = None
         self.max_open_trades = None
@@ -77,6 +78,7 @@ class ConfigModule(object):
             print_warning(f"Warning: Exposure is not 100% (default), this means that every trade will use {config_module.exposure_per_trade * 100}% funds per trade until either all funds are used or max open trades are open.")
         config_module.plots = config["plots"]
         config_module.tearsheet = config.get("tearsheet", False)
+        config_module.export_result = config.get("export_result", False)
         config_module.roi = config["roi"]
         config_module.currency_symbol = get_currency_symbol(config_module.raw_config)
         return config_module

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -78,7 +78,7 @@ class ConfigModule(object):
             print_warning(f"Warning: Exposure is not 100% (default), this means that every trade will use {config_module.exposure_per_trade * 100}% funds per trade until either all funds are used or max open trades are open.")
         config_module.plots = config["plots"]
         config_module.tearsheet = config.get("tearsheet", False)
-        config_module.export_result = config.get("export_result", False)
+        config_module.export_result = config.get("export-result", False)
         config_module.roi = config["roi"]
         config_module.currency_symbol = get_currency_symbol(config_module.raw_config)
         return config_module

--- a/modules/stats/get_stats_config.py
+++ b/modules/stats/get_stats_config.py
@@ -15,6 +15,7 @@ def get_stats_config(config: ConfigModule, btc_marketchange_ratio: float, btc_dr
         backtesting_from=config.backtesting_from,
         plots=config.plots,
         tearsheet=config.tearsheet,
+        export_result=config.export_result,
         starting_capital=config.starting_capital,
         currency_symbol=config.currency_symbol,
         mainplot_indicators=config.mainplot_indicators,

--- a/modules/stats/stats_config.py
+++ b/modules/stats/stats_config.py
@@ -17,5 +17,6 @@ class StatsConfig:
     backtesting_from: int
     plots: bool
     tearsheet: bool
+    export_result: bool
     starting_capital: float
     currency_symbol: Literal["USDT"]

--- a/resources/specification.json
+++ b/resources/specification.json
@@ -134,5 +134,13 @@
     "cli": {
       "short": "hy"
     }
+  },
+  {
+    "name": "export_result",
+    "type": "bool",
+    "default": false,
+    "cli": {
+      "short": "ex"
+    }
   }
 ]

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -37,6 +37,7 @@ class StatsFixture:
             currency_symbol="USDT",
             plots=False,
             tearsheet=False,
+            export_result=False,
 
             mainplot_indicators=[],
             subplot_indicators=[]


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes #


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
When the `export_result` setting is set through the config file or CLI, the main results are written to a json file in the `data/backtesting-data/` folder.
