### PR TITLE
Set time as index after joining additional data

### DIFF
--- a/backtesting/strategy.py
+++ b/backtesting/strategy.py
@@ -109,6 +109,9 @@ class Strategy(abc.ABC):
         if ffill:
             dataframe = dataframe.ffill()
 
+        # reset time column back as index
+        dataframe.set_index('time', drop=False, inplace=True)
+
         return dataframe
 
     def loss_function(self, stats: TradingStats) -> float:


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes #371 

# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
* Resets index with time after merging additional data