### PR TITLE
change standard stoploss to static stoploss

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,7 @@
   "backtesting-from": "2021-03-11",
   "backtesting-to": "2021-03-22",
   "backtesting-till-now": "False",
-  "stoploss-type": "standard",
+  "stoploss-type": "static",
   "stoploss": "-20",
   "roi": {
     "0": 5,

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "backtesting-from": "2020-09-01",
   "backtesting-to": "2021-09-01",
   "backtesting-till-now": false,
-  "stoploss-type": "standard",
+  "stoploss-type": "static",
   "stoploss": -10,
   "roi": {
     "0": 5,

--- a/modules/algo/backtesting.py
+++ b/modules/algo/backtesting.py
@@ -47,8 +47,6 @@ class BackTesting:
         Populates indicators
         Populates buy signal
         Populates sell signal
-        :return: dict containing OHLCV data per pair
-        @param trial:
         """
         data_dict = {}
         notify = False
@@ -87,6 +85,9 @@ class BackTesting:
                     "Cannot set OHLCV data in strategy.")
                 sys.exit()
         if notify:
-            print_warning(f"Dynamic stoploss {notify_reason}. Using standard stoploss of "
+            print_warning(f"Dynamic stoploss {notify_reason}. Using static stoploss of "
                           f"{self.config.stoploss}%.")
+        if stoploss_type == 'standard':
+            self.config.stoploss_type = 'static'
+            print_warning(f"The use of 'standard' is deprecated. Using static stoploss of {self.config.stoploss}%.")
         return data_dict

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -43,6 +43,7 @@ def format_time_difference(avg_trade_duration_unformatted: timedelta) -> str:
         avg_trade_duration = '-'
     return avg_trade_duration
 
+
 def show_mainresults(self: MainResults, currency_symbol: str):
     # Update variables for prettier terminal output
     drawdown_from_string = timestamp_to_string(self.drawdown_from)

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -35,6 +35,9 @@ class StatsModule:
         self.trading_module = trading_module
         self.frame_with_signals = frame_with_signals
 
+        if self.config.stoploss_type == 'standard':
+            self.config.stoploss_type = 'static'
+
     def analyze(self) -> TradingStats:
         pairs = list(self.frame_with_signals.keys())
         ticks = list(self.frame_with_signals[pairs[0]].keys()) if pairs else []

--- a/modules/stats/trade.py
+++ b/modules/stats/trade.py
@@ -57,16 +57,6 @@ class Trade:
         self.update_profits()
 
     def close_trade(self, reason: SellReason, date: datetime) -> None:
-        """
-        Closes this trade and updates stats according to latest data.
-
-        :param reason: reason why trade is closed
-        :type reason: string
-        :param date: date at which trade is opened
-        :type date: datetime
-        :return: None
-        :rtype: None
-        """
         self.status = 'closed'
         self.sell_reason = reason
         self.close = self.current
@@ -94,14 +84,16 @@ class Trade:
             if 'stoploss' in ohlcv:
                 self.sl_sell_time, self.sl_ratio = self.dynamic_stoploss(data_dict, ohlcv['time'])
             else:
-                self.sl_type = 'standard'   # when dynamic not configured use normal stoploss
-        if self.sl_type == 'standard':
+                self.sl_type = 'static'   # when dynamic not configured use static stoploss
+        if self.sl_type == 'standard':   # for backwards compatability - can be removed in the future
+            self.sl_type = 'static'
+        if self.sl_type == 'static':
             self.sl_ratio = 1 - (abs(self.sl_perc) / 100)
         elif self.sl_type == 'trailing':
             self.sl_sell_time, self.sl_ratio = self.trailing_stoploss(data_dict, ohlcv['time'])
 
     def check_for_sl(self, ohlcv: dict) -> bool:
-        if self.sl_type == 'standard':
+        if self.sl_type == 'static':
             lowest_ratio = (ohlcv['low'] * self.currency_amount) / self.starting_amount
             if lowest_ratio <= self.sl_ratio:
                 self.current = (self.sl_ratio * self.starting_amount) / self.currency_amount

--- a/modules/stats/tradingmodule_config.py
+++ b/modules/stats/tradingmodule_config.py
@@ -13,7 +13,7 @@ class TradingModuleConfig:
     roi: dict
     starting_capital: float
     stoploss: float
-    stoploss_type: Literal["standard", "trailing", "dynamic"]
+    stoploss_type: Literal["static", "trailing", "dynamic"]
 
 
 def create_trading_module_config(config: ConfigModule):

--- a/resources/specification.json
+++ b/resources/specification.json
@@ -65,8 +65,9 @@
   },
   {
     "name": "stoploss-type",
-    "default": "standard",
+    "default": "static",
     "options": [
+      "static",
       "standard",
       "trailing",
       "dynamic"

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -33,7 +33,7 @@ class StatsFixture:
             fee=FEE_PERCENTAGE,
 
             stoploss=STOPLOSS,
-            stoploss_type="standard",
+            stoploss_type="static",
             currency_symbol="USDT",
             plots=False,
             tearsheet=False,
@@ -50,7 +50,7 @@ class StatsFixture:
             starting_capital=STARTING_CAPITAL,
             fee=FEE_PERCENTAGE,
             pairs=pairs,
-            stoploss_type="standard",
+            stoploss_type="static",
             roi={"0": int(9999999999)}
         )
 


### PR DESCRIPTION
Renaming of the 'standard' stoploss value - it is now called 'static'. Checks have been built in for backwards compatability - if someone now uses 'standard', they will get a warning and the stoploss type will be automatically set on 'static'.