### PR TITLE
Fix for the 'winning draw losing weeks' bug

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "exchange": "binance",
   "timeframe": "5m",
-  "max-open-trades": 1,
+  "max-open-trades": 3,
   "exposure-per-trade": 100,
   "starting-capital": 1000,
   "backtesting-from": "2020-09-01",
@@ -14,7 +14,7 @@
     "60": 4,
     "120": 3
   },
-  "pairs": ["BTC/USDT"],
+  "pairs": ["BTC/USDT", "LTC/USDT", "ETH/USDT"],
   "currency": "USDT",
   "fee": 0.25,
   "strategy-name": "MyStrategy",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "exchange": "binance",
   "timeframe": "5m",
-  "max-open-trades": 3,
+  "max-open-trades": 1,
   "exposure-per-trade": 100,
   "starting-capital": 1000,
   "backtesting-from": "2020-09-01",
@@ -14,7 +14,7 @@
     "60": 4,
     "120": 3
   },
-  "pairs": ["BTC/USDT", "LTC/USDT", "ETH/USDT"],
+  "pairs": ["BTC/USDT"],
   "currency": "USDT",
   "fee": 0.25,
   "strategy-name": "MyStrategy",

--- a/modules/stats/metrics/winning_weeks.py
+++ b/modules/stats/metrics/winning_weeks.py
@@ -1,11 +1,24 @@
+import math
 from datetime import datetime
 from pandas import DataFrame
+
+from modules.stats.metrics.profit_ratio import with_copied_initial_row
+
+
+def get_market_ratio(signal_dict):
+    df = DataFrame(signal_dict.values()).set_index("time")
+    df = with_copied_initial_row(df)
+    df["close"] = df["close"].fillna(None, 'ffill')
+    df["market_ratio"] = (df["close"] / df["close"].shift(1))
+    df["market_ratio"] = df["market_ratio"].fillna(1)
+    return df
 
 
 def get_winning_weeks_per_coin(signal_dict: dict, cum_profit_ratio):
     # Create dataframes
-    ohlcv_df = DataFrame(signal_dict.values()).set_index("time")
     cum_profit_ratio = cum_profit_ratio.iloc[1:]
+    ohlcv_df = get_market_ratio(signal_dict)
+    ohlcv_df = ohlcv_df.iloc[1:]
 
     # Refactor index of dataframes
     datetime_index = [datetime.fromtimestamp(ms / 1000.0) for ms in ohlcv_df.index]
@@ -13,19 +26,20 @@ def get_winning_weeks_per_coin(signal_dict: dict, cum_profit_ratio):
     cum_profit_ratio.index = datetime_index
 
     # Resample dataframes to one week
-    coin_close_price_weekly = ohlcv_df['close'].resample('W', origin='start').ohlc()
-    cum_profit_ratio_weekly = cum_profit_ratio['profit_ratio'].resample('W', origin='start').prod()
-
-    # Calculate market change
-    market_change_weekly = \
-        coin_close_price_weekly['close'] / coin_close_price_weekly['open']
+    market_change_weekly = round_down(ohlcv_df['market_ratio'], 6).resample('W', origin='start').prod()
+    cum_profit_ratio_weekly = round_down(cum_profit_ratio['profit_ratio'], 6).resample('W', origin='start').prod()
 
     # Define the winning weeks
-    wins = len(cum_profit_ratio_weekly[cum_profit_ratio_weekly > market_change_weekly])
-    losses = len(cum_profit_ratio_weekly[cum_profit_ratio_weekly < market_change_weekly])
+    wins = len(cum_profit_ratio_weekly[cum_profit_ratio_weekly > market_change_weekly + 0.001])
+    losses = len(cum_profit_ratio_weekly[cum_profit_ratio_weekly < market_change_weekly - 0.001])
     draws = len(cum_profit_ratio_weekly) - wins - losses
 
-    return wins, draws, losses, market_change_weekly
+    # Calculate weekly change for portfolio overview
+    coin_close_price_weekly = ohlcv_df['close'].resample('W', origin='start').ohlc()
+    market_change_weekly_portfolio = \
+        coin_close_price_weekly['close'] / coin_close_price_weekly['open']
+
+    return wins, draws, losses, market_change_weekly_portfolio
 
 
 def get_winning_weeks_for_portfolio(capital_per_timestamp, market_change_weekly):
@@ -41,12 +55,17 @@ def get_winning_weeks_for_portfolio(capital_per_timestamp, market_change_weekly)
         # Calculate average market change
         combined_market_change_df['avg_market_change'] = combined_market_change_df.mean(axis=1)
 
+        # add the starting capital to the timeframe in a sensible timestep, in order to take buy fee into account
+        capital_per_timestamp[list(capital_per_timestamp.keys())[1] - 1] = capital_per_timestamp[0]
         # Create dataframe for capital per timestamp
         capital_per_timestamp_df = DataFrame(capital_per_timestamp.values(),
                                              index=capital_per_timestamp.keys(),
                                              columns=['capital']).iloc[1:]
 
         profit_ratio = capital_per_timestamp_df['capital'].div(capital_per_timestamp_df['capital'].shift(1))
+        profit_ratio.index = \
+            [datetime.fromtimestamp(ms / 1000.0) for ms in profit_ratio.index]
+
         # Set index to datetime and resample to one week
         capital_per_timestamp_df.index = \
             [datetime.fromtimestamp(ms / 1000.0) for ms in capital_per_timestamp_df.index]
@@ -57,11 +76,15 @@ def get_winning_weeks_for_portfolio(capital_per_timestamp, market_change_weekly)
             capital_per_timestamp_weekly['close'] / capital_per_timestamp_weekly['open']
 
         # Define the winning weeks
-        wins = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'].round(10) >
-                                                combined_market_change_df['avg_market_change'].round(10)])
-        losses = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'].round(10) <
-                                                  combined_market_change_df['avg_market_change'].round(10)])
+        wins = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'] >
+                                                (combined_market_change_df['avg_market_change'] + 0.001)])
+        losses = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'] <
+                                                  (combined_market_change_df['avg_market_change'] - 0.001)])
         draws = len(capital_per_timestamp_weekly) - wins - losses
 
         return wins, draws, losses
     return 0, 0, 0
+
+
+def round_down(dataframe, decimals):
+    return ((dataframe.fillna(1) * (10 ** decimals)).apply(math.floor)) / (10 ** decimals)

--- a/modules/stats/metrics/winning_weeks.py
+++ b/modules/stats/metrics/winning_weeks.py
@@ -46,6 +46,7 @@ def get_winning_weeks_for_portfolio(capital_per_timestamp, market_change_weekly)
                                              index=capital_per_timestamp.keys(),
                                              columns=['capital']).iloc[1:]
 
+        profit_ratio = capital_per_timestamp_df['capital'].div(capital_per_timestamp_df['capital'].shift(1))
         # Set index to datetime and resample to one week
         capital_per_timestamp_df.index = \
             [datetime.fromtimestamp(ms / 1000.0) for ms in capital_per_timestamp_df.index]
@@ -56,10 +57,11 @@ def get_winning_weeks_for_portfolio(capital_per_timestamp, market_change_weekly)
             capital_per_timestamp_weekly['close'] / capital_per_timestamp_weekly['open']
 
         # Define the winning weeks
-        wins = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'] >
-                                                combined_market_change_df['avg_market_change']])
-        losses = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'] <
-                                                  combined_market_change_df['avg_market_change']])
+        wins = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'].round(10) >
+                                                combined_market_change_df['avg_market_change'].round(10)])
+        losses = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'].round(10) <
+                                                  combined_market_change_df['avg_market_change'].round(10)])
         draws = len(capital_per_timestamp_weekly) - wins - losses
+
         return wins, draws, losses
     return 0, 0, 0


### PR DESCRIPTION
The winning draw losing weeks metric was not the same for the general overview, and coin insight. This PR fixes that, by calculating the market ratio in the same way as the profit ratio is calculated, and removing rounding errors. It also broadens the scope of a 'draw' from 'exactly the same' to 'in a 0.001 range'.