### PR TITLE
Add Winning and Losing trades metric to coin insight

### DIFF
--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -188,6 +188,8 @@ class CoinInsights:
     avg_profit_percentage: float
     profit: float
     n_trades: int
+    n_wins: int
+    n_losses: int
     market_change: float
     market_drawdown: float
     max_seen_drawdown: float
@@ -229,11 +231,11 @@ class CoinInsights:
                                        colorize(round(c.market_drawdown, 2), 0),
                                        colorize(round(c.max_seen_drawdown, 2), 0),
                                        colorize(round(c.max_realised_drawdown, 2), 0),
-                                       f"{c.win_weeks} / {c.draw_weeks} / {c.loss_weeks}",
+                                       f"{c.win_weeks} / {c.draw_weeks}/ {c.loss_weeks}",
                                        )
 
             coin_signal_table.add_row(c.pair,
-                                      str(c.n_trades),
+                                      f"{c.n_trades} ([bright_green]{c.n_wins}[/bright_green]/[bright_red]{c.n_losses}[/bright_red])",
                                       str(shortest_trade_duration),
                                       str(avg_trade_duration),
                                       str(longest_trade_duration),
@@ -253,7 +255,7 @@ class CoinInsights:
     def create_coin_signals_table(justification) -> Table:
         coin_signal_table = Table(title="Coin Signals", box=box.ROUNDED, width=100)
         coin_signal_table.add_column("Pair", justify=justification)
-        coin_signal_table.add_column("Trades", justify=justification)
+        coin_signal_table.add_column("Trades (W/L)", justify=justification)
         coin_signal_table.add_column("Shortest trade duration", justify=justification)
         coin_signal_table.add_column("Avg. trade duration", justify=justification)
         coin_signal_table.add_column("Longest trade duration", justify=justification)

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -169,6 +169,8 @@ class StatsModule:
 
             coin_insight = CoinInsights(pair=coin,
                                         n_trades=stats[coin]['amount_of_trades'],
+                                        n_wins=stats[coin]['amount_of_winning_trades'],
+                                        n_losses=stats[coin]['amount_of_losing_trades'],
                                         market_change=(market_change[coin] - 1) * 100,
                                         market_drawdown=(market_drawdown[coin] - 1) * 100,
                                         cum_profit_percentage=stats[coin]['cum_profit_prct'],
@@ -197,6 +199,8 @@ class StatsModule:
                 'total_profit_ratio': 1.0,
                 'total_profit_amount': 0.0,
                 'amount_of_trades': 0,
+                'amount_of_winning_trades': 0,
+                'amount_of_losing_trades': 0,
                 'peak_ratio': 1.0,
                 'drawdown_ratio': 1.0,
                 'total_ratio': 1.0,
@@ -260,6 +264,10 @@ class StatsModule:
                 # Update profit and amount of trades
                 per_coin_stats[key]['total_profit_amount'] += trade.profit_dollar
                 per_coin_stats[key]['amount_of_trades'] += 1
+                if trade.profit_ratio > 1:
+                    per_coin_stats[key]['amount_of_winning_trades'] += 1
+                if trade.profit_ratio < 1:
+                    per_coin_stats[key]['amount_of_losing_trades'] += 1
                 per_coin_stats[key]['sell_reasons'][trade.sell_reason] += 1
 
                 # Check for max realised drawdown


### PR DESCRIPTION
Addition of "winning and losing trades" metric to coin signals.

![image](https://user-images.githubusercontent.com/14127457/139434234-96836a90-1a22-4b1f-8f93-0b7af266191c.png)
