### PR TITLE
Fix Error Budget Low appearing when max open trades is reached

### DIFF
--- a/modules/stats/tradingmodule.py
+++ b/modules/stats/tradingmodule.py
@@ -95,14 +95,15 @@ class TradingModule:
         self.update_realised_profit(trade)
 
     def open_trade(self, ohlcv: dict, data_dict: dict) -> None:
-        if self.budget <= 0:
-            print_info("Budget is running low, cannot buy")
-            return
 
         # Find available trade spaces
         open_trades = len(self.open_trades)
         available_spaces = self.max_open_trades - open_trades
         if available_spaces == 0:
+            return
+
+        if self.budget <= 0:
+            print_info("Budget is running low, cannot buy")
             return
 
         # Define spend amount based on realised profit


### PR DESCRIPTION
Only show "Error Budget Low" warning when max open trades is not yet reached.