### PR TITLE
Fix Drawdown period from start not shown

### DIFF
--- a/modules/stats/drawdown/for_portfolio.py
+++ b/modules/stats/drawdown/for_portfolio.py
@@ -20,6 +20,10 @@ def get_max_seen_drawdown_for_portfolio(capital_per_timestamp: dict):
     else:
         max_seen_drawdown["to"] = 0
 
+    # if drawdown is from the very first timestep
+    if max_seen_drawdown["from"] == 0:
+        max_seen_drawdown["from"] = df.index[1]
+
     return max_seen_drawdown
 
 

--- a/test/stats/test_drawdowns.py
+++ b/test/stats/test_drawdowns.py
@@ -97,8 +97,8 @@ def test_simple_seen_drawdown():
 
     # Assert
     assert math.isclose(stats.main_results.max_seen_drawdown, -50.995)
-    assert stats.main_results.drawdown_from == 0
-    assert stats.main_results.drawdown_to == 0
+    assert stats.main_results.drawdown_from == 1  # not zero, because the first row is copied for fee calc purposes
+    assert stats.main_results.drawdown_to == 0  # zero, because the drawdown hasn't ended yet
     assert stats.main_results.drawdown_at == 2
 
 
@@ -114,7 +114,7 @@ def test_simple_no_seen_drawdown():
 
     # Assert
     assert math.isclose(stats.main_results.max_seen_drawdown, -1)
-    assert stats.main_results.drawdown_from == 0
+    assert stats.main_results.drawdown_from == 1
     assert stats.main_results.drawdown_to == 2
     assert stats.main_results.drawdown_at == 1
     
@@ -176,7 +176,7 @@ def test_multiple_periods_seen_drawdown_easy():
 
     # Assert
     assert math.isclose(stats.main_results.max_seen_drawdown, -59.1625)
-    assert stats.main_results.drawdown_from == 0
+    assert stats.main_results.drawdown_from == 1
     assert stats.main_results.drawdown_to == 0
     assert stats.main_results.drawdown_at == 2
 


### PR DESCRIPTION
Fixes the error that shows up when your drawdown period starts at the first timestep. The 'backtesting from' was set to the copied first row, that's used for fee purposes, but has timestamp 0. This PR fixes that, and also fixes the tests that were not correct due to this bug.