### PR TITLE
Add ability for equity plots be exported with the strategy name

### DIFF
--- a/modules/output/equity_plot.py
+++ b/modules/output/equity_plot.py
@@ -48,4 +48,4 @@ def equity_plot(capital_dict, strategy_name):
         title_x=0.5
     )
     fig.update_layout(yaxis_type="log", yaxis_range=[log10(min_value), log10(max_value)])
-    fig.write_html("data/backtesting-data/plots/equity/equityplot.html", auto_open=False)
+    fig.write_html(f"data/backtesting-data/plots/equity/{strategy_name}.html", auto_open=False)

--- a/modules/output/equity_plot.py
+++ b/modules/output/equity_plot.py
@@ -55,4 +55,4 @@ def equity_plot(capital_dict, strategy_name):
         }
     }
 
-    fig.write_html(f"data/backtesting-data/plots/equity/equityplot.html", auto_open=False, config=config)
+    fig.write_html("data/backtesting-data/plots/equity/equityplot.html", auto_open=False, config=config)

--- a/modules/output/equity_plot.py
+++ b/modules/output/equity_plot.py
@@ -48,4 +48,4 @@ def equity_plot(capital_dict, strategy_name):
         title_x=0.5
     )
     fig.update_layout(yaxis_type="log", yaxis_range=[log10(min_value), log10(max_value)])
-    fig.write_html(f"data/backtesting-data/plots/equity/{strategy_name}.html", auto_open=False)
+    fig.write_html(f"data/backtesting-data/plots/equity/equityplot.html", auto_open=False)

--- a/modules/output/equity_plot.py
+++ b/modules/output/equity_plot.py
@@ -48,4 +48,11 @@ def equity_plot(capital_dict, strategy_name):
         title_x=0.5
     )
     fig.update_layout(yaxis_type="log", yaxis_range=[log10(min_value), log10(max_value)])
-    fig.write_html(f"data/backtesting-data/plots/equity/equityplot.html", auto_open=False)
+
+    config = {
+        'toImageButtonOptions': {
+            'filename': f'{strategy_name}'
+        }
+    }
+
+    fig.write_html(f"data/backtesting-data/plots/equity/equityplot.html", auto_open=False, config=config)


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Equity plots are saved using the strategy name rather than 'equityplot'.