### PR TITLE
Fixes "can't compare identically-labeled series" error

### DIFF
--- a/modules/setup/datamodule.py
+++ b/modules/setup/datamodule.py
@@ -269,6 +269,9 @@ class DataModule:
         nandf["time"] = daterange
         nandf["pair"] = pair
 
+        # Removes identically-labeled rows such that comparison is possible
+        df = df.loc[~df.index.duplicated(), :]
+
         nandf.update(df)
         return nandf
 


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes the following error that occurs on some random timerange intervals

```
Traceback (most recent call last):
  File "/usr/src/engine/main.py", line 46, in <module>
    main()
  File "/usr/src/engine/main.py", line 25, in main
    execute_for_args({
  File "/usr/src/engine/cli/arg_parse.py", line 41, in execute_for_args
    args.func(args)
  File "/usr/src/engine/main.py", line 34, in run_engine
    asyncio.get_event_loop().run_until_complete(controller.run(args))
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/usr/src/engine/main_controller.py", line 25, in run
    runner.run_outputted_backtest()
  File "/usr/src/engine/backtest_runner.py", line 35, in run_outputted_backtest
    stats = self.run_backtest()
  File "/usr/src/engine/backtest_runner.py", line 27, in run_backtest
    return stats_module.analyze()
  File "/usr/src/engine/modules/stats/stats.py", line 53, in analyze
    return self.generate_backtesting_result(market_change, market_drawdown)
  File "/usr/src/engine/modules/stats/stats.py", line 63, in generate_backtesting_result
    main_results = self.generate_main_results(
  File "/usr/src/engine/modules/stats/stats.py", line 106, in generate_main_results
    win_weeks, draw_weeks, loss_weeks = get_winning_weeks_for_portfolio(
  File "/usr/src/engine/modules/stats/metrics/winning_weeks.py", line 81, in get_winning_weeks_for_portfolio
    wins = len(capital_per_timestamp_weekly[capital_per_timestamp_weekly['weekly_profit'] >
  File "/usr/local/lib/python3.9/site-packages/pandas/core/ops/common.py", line 65, in new_method
    return method(self, other)
  File "/usr/local/lib/python3.9/site-packages/pandas/core/arraylike.py", line 45, in __gt__
    return self._cmp_method(other, operator.gt)
  File "/usr/local/lib/python3.9/site-packages/pandas/core/series.py", line 4970, in _cmp_method
    raise ValueError("Can only compare identically-labeled Series objects")
ValueError: Can only compare identically-labeled Series objects
```


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
An extra line has been added to the data module which removes the duplicated indexes. This allows the `update()` function to work properly.
