### PR TITLE
fix trade log message

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -39,7 +39,7 @@ class OutputModule(object):
         except OSError:
             pass
 
-        print_info("Logging trades to " + FONT_BOLD + "data/backtesting-data/trades_log.json" + FONT_RESET + "...")
+        print_info("Logging trades to " + FONT_BOLD + f"data/backtesting-data/trades_log_{self.config.strategy_name}.json" + FONT_RESET + "...")
         log_trades(stats, self.config)
 
         # write orders to a  tearsheet


### PR DESCRIPTION
# Results of merging this
<!-- Link the corresponding issue number  -->
Fixes the trade log generation message in the backtesting output to match the new filename structure introduced in #434.


# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Now you'll see:
`[INFO] Logging trades to data/backtesting-data/trades_log_MyStrategy.json...`


