### PR TITLE
Add trade fee to trade logs

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -74,7 +74,12 @@ def show_trade_anomalies(stats: TradingStats):
 
 
 def log_trades(stats: TradingStats, config: StatsConfig):
-    trades_dict = {"max-open_trades": config.max_open_trades, "timeframe": config.timeframe, "trades": {}}
+    trades_dict = {
+        "max-open-trades": config.max_open_trades,
+        "timeframe": config.timeframe,
+        "fee-percentage": config.fee,
+        "trades": {}
+    }
     for i, trade in enumerate(stats.trades):
         trade_dict = {'status': trade.status,
                       'opened_at': trade.opened_at,
@@ -82,7 +87,9 @@ def log_trades(stats: TradingStats, config: StatsConfig):
                       'pair': trade.pair,
                       'open_price': trade.open,
                       'close_price': trade.close,
-                      'fee_paid': trade.fee,
+                      'fee_paid_open': trade.fee_paid_open,
+                      'fee_paid_close': trade.fee_paid_close,
+                      'fee_paid_total': trade.fee_paid_total,
                       'starting_amount': trade.starting_amount,
                       'capital': trade.capital,
                       'currency_amount': trade.currency_amount,

--- a/modules/stats/trade.py
+++ b/modules/stats/trade.py
@@ -40,12 +40,15 @@ class Trade:
         self.closed_at = None
         self.close = None
         self.fee = fee
+        self.fee_paid_open = spend_amount * fee
+        self.fee_paid_close = None
+        self.fee_paid_total = self.fee_paid_open
         self.sell_reason = SellReason.NONE
 
         # Calculations for trade worth
         self.max_seen_drawdown = 1.0  # ratio
         self.starting_amount = spend_amount
-        self.capital = spend_amount - (spend_amount * fee)  # apply fee
+        self.capital = spend_amount - self.fee_paid_open  # apply fee
         self.capital_per_timestamp = {}
         self.currency_amount = (self.capital / ohlcv['close'])
 
@@ -61,9 +64,10 @@ class Trade:
         self.sell_reason = reason
         self.close = self.current
         self.closed_at = date
-        self.close_fee_paid = self.capital * self.fee   # final issued fee
+        self.fee_paid_close = self.capital * self.fee   # final issued fee
+        self.fee_paid_total += self.fee_paid_close
 
-        self.capital -= self.close_fee_paid
+        self.capital -= self.fee_paid_close
         self.update_profits(update_capital=False)
 
     def update_stats(self, ohlcv: dict, first: bool = False) -> None:

--- a/modules/stats/tradingmodule.py
+++ b/modules/stats/tradingmodule.py
@@ -80,15 +80,14 @@ class TradingModule:
         if trade.sell_reason == SellReason.STOPLOSS_AND_ROI:
             # Because trade had no impact on results, remove first issued fee from
             # total amount of fee and reset trade stats.
-            first_fee = trade.starting_amount * trade.fee
-            self.total_fee_paid -= first_fee
+            self.total_fee_paid -= trade.fee_paid_open
 
             # Reset trade stats
             trade.capital = trade.starting_amount
             trade.update_profits(update_capital=False)
             trade.max_seen_drawdown = 1.0
         else:
-            self.total_fee_paid += trade.close_fee_paid
+            self.total_fee_paid += trade.fee_paid_close
         self.budget += trade.capital
 
         self.open_trades.remove(trade)


### PR DESCRIPTION
# Results of merging this
Adds the 'fee percentage' to the trade log header, and adds open trade fee, close trade fee, and total fee paid to the trade log on a per-trade level.