### PR TITLE
Remove old trade log

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -92,6 +92,12 @@ def log_trades(stats: TradingStats, config: StatsConfig):
 
     trades_json = json.dumps(trades_dict, indent=4, default=str)
 
+    # remove the old trade log file. Can be removed in the future.
+    try:
+        os.remove('./data/backtesting-data/trades_log.json')
+    except FileNotFoundError:
+        pass
+
     with open(f'./data/backtesting-data/trades_log_{config.strategy_name}.json', 'w', encoding='utf-8') as f:
         f.write(trades_json)
 


### PR DESCRIPTION
# Results of merging this
Removes the old trade log, if it exists, in order to make it less confusing for our users.
This block of code can be removed in future versions, when we're reasonably sure that the old trade logs are no longer existent on our user's local versions.