### PR TITLE
Change timezone for Github Actions

### DIFF
--- a/.github/workflows/PR-Push-test.yml
+++ b/.github/workflows/PR-Push-test.yml
@@ -6,6 +6,12 @@ jobs:
   pytest-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Set Timezone
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Europe/Amsterdam"
+          timezoneMacos: "Europe/Amsterdam"
+          timezoneWindows: "Central European Time"
       - uses: actions/checkout@v2
       - name: Run Pytest and create a coverage report
         uses: actions/setup-python@v2


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Since Github Actions uses a different timezone, it sometimes won't pass tests, so we're changing to our timezone.