### PR TITLE
Add average market change line to equity plot

### DIFF
--- a/modules/output/__init__.py
+++ b/modules/output/__init__.py
@@ -51,7 +51,7 @@ class OutputModule(object):
         if self.config.plots:
             print_info("Creating plots in " + FONT_BOLD + "data/backtesting-data/plots" + FONT_RESET + "...")
             plot_per_coin(stats, config=self.config)
-            equity_plot(stats.capital_per_timestamp, self.config.strategy_definition.strategy_name)
+            equity_plot(stats, self.config.strategy_definition.strategy_name)
         print_info("Backtest finished!")
 
         # Export backtest result as JSON

--- a/modules/output/equity_plot.py
+++ b/modules/output/equity_plot.py
@@ -14,7 +14,7 @@ def equity_plot(stats: TradingStats, strategy_name):
 
     df_capital, dates = convert_df_for_plotting(df_capital)
 
-    df_coins = compute_average_market_change(stats.df, stats.capital_per_timestamp[0])
+    df_average_market_change = compute_average_market_change(stats.df, stats.capital_per_timestamp[0])
 
     # Define various traces to be plotted
     data = [
@@ -26,10 +26,10 @@ def equity_plot(stats: TradingStats, strategy_name):
             "fill": 'tozeroy'
         },
         {
-            "name": "Average market change",
+            "name": "Average Market Change",
             "mode": "lines",
             "x": dates,
-            "y": df_coins['avg_market_change']
+            "y": df_average_market_change['avg_market_change']
         }
     ]
 

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -147,7 +147,7 @@ def create_performance_table(self, currency_symbol, drawdown_at_string, drawdown
                               drawdown_from_string)
     performance_table.add_row('Max. seen drawdown to', drawdown_to_string)
     performance_table.add_row('Max. seen drawdown at', drawdown_at_string)
-    performance_table.add_row('Market change coins',
+    performance_table.add_row('Average market change',
                               colorize(round(self.market_change_coins,
                                              2), 0, '%'))
     performance_table.add_row('Market change BTC/USDT',


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Added a trace to the equity plot tracking the average market change for all coins 

# Potential Issues / Future considerations
<!--  Did you encounter anything that could potentially cause problems in the future? Or how could this PR be improved in the future?-->
The computation of the average starting capital assumes an equal division between all coins. This will need to be refactored once we allow users to specify how to allocate the funds.


# Assumptions made / Things to add to the wiki
<!-- Did you make any assumptions during this development? Certain flows or logic? This could be quite broad, but it's
 very crucial to avoid misconceptions regarding the working of the Engine --> 
Might be good to add (if not already the case) in the docs that plotly allows the traces to be toggled by clicking on their respective legends
