### PR TITLE
Quiet Tests

### DIFF
--- a/cli/print_utils.py
+++ b/cli/print_utils.py
@@ -8,7 +8,7 @@ def get_verbosity():
     return os.getenv("VERBOSITY") or "none"
 
 
-def is_verbosity(verbosity: Literal["debug", "none"]):
+def is_verbosity(verbosity: Literal["quiet", "debug", "none"]):
     return get_verbosity() == verbosity
 
 
@@ -22,6 +22,8 @@ class ConsoleColors:
 
 
 def print_warning(text):
+    if is_verbosity("quiet"):
+        return
     console_standard.print("[WARNING] ", end='')
     console_color.print(f"{ConsoleColors.WARNING}{text}[/]")
 
@@ -37,6 +39,8 @@ def print_config_error(text: str):
 
 
 def print_info(text: str):
+    if is_verbosity("quiet"):
+        return
     console_standard.print(f"[INFO] {text}")
 
 

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 
 from modules.stats.stats import StatsModule
@@ -6,6 +8,8 @@ from modules.stats.tradingmodule import TradingModule
 from modules.stats.tradingmodule_config import TradingModuleConfig
 from test.utils.signal_frame import MockPairFrame
 from utils.utils import get_ohlcv_indicators
+
+os.environ["VERBOSITY"] = "quiet"  # disables printing of info and warning messages
 
 StatsModuleFactory = [[], StatsModule]
 


### PR DESCRIPTION
# Results of merging this
Removes the "UNABLE TO COMPUTE SHARPE RATIO" and all other irrelevant warning and info messages when testing. Still shows error messages.