### PR TITLE
[Feat] Add qtpylib

### DIFF
--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -3,6 +3,9 @@ import talib.abstract as ta
 from pandas import DataFrame
 from backtesting.strategy import Strategy
 
+# Optional Imports
+from modules.setup.config import qtpylib_methods as qtpylib
+
 
 class MyStrategy(Strategy):
     """

--- a/resources/setup/strategies/my_strategy_advanced.py
+++ b/resources/setup/strategies/my_strategy_advanced.py
@@ -5,6 +5,7 @@ from backtesting.strategy import Strategy
 
 # Optional Imports
 import numpy as np
+from modules.setup.config import qtpylib_methods as qtpylib
 
 
 class MyStrategyAdvanced(Strategy):


### PR DESCRIPTION
# Results of merging this
Adds qtpylib imports to standard strategy files. Is needed for some indicators, and it's neater if we already include it in the imports.

This does mean that there are two unused imports added - Codacy is likely going to complain about this, this can be safely ignored.