### PR TITLE
[Fix] Increase max build time for windows and mac executable

### DIFF
--- a/.github/workflows/build_executables_mac.yml
+++ b/.github/workflows/build_executables_mac.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/build_executables_windows.yml
+++ b/.github/workflows/build_executables_windows.yml
@@ -8,7 +8,7 @@ on:
       - development
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       TALIB_URL: TA_Lib-0.4.20-cp39-cp39-win_amd64.whl
     runs-on: windows-latest


### PR DESCRIPTION
# Results of merging this
The max build time for both windows and mac executable was set to 10 minutes. Lately we keep having builds fail because they hit that 10 minute mark. This PR increases that to 15 minutes - so builds that take just above 10 minutes don't fail and we don't have to rerun as many jobs.