### PR TITLE
[Fix] Remove Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# This file signifies the code owners for specific files.
-# These code owners will be notified and auto-asked for reviews of pull requests
-# that change things in files that they own.
-
-requirements.txt @keebrev
-requirements-ci.txt @keebrev


### PR DESCRIPTION
# Results of merging this
Removes the codeowner files so Tijs doesn't get asked to review PR's for the Engine anymore.