### PR TITLE
[Feat] Add buy cooldown

### DIFF
--- a/backtest_runner.py
+++ b/backtest_runner.py
@@ -24,7 +24,7 @@ class BacktestRunner:
 
     def run_backtest(self):
         pair_dicts, dict_with_signals = self.algo_module.run()
-        trading_module = TradingModule(self.trading_module_config)
+        trading_module = TradingModule(self.trading_module_config, self.strategy)
         stats_module = StatsModule(self.stats_config, dict_with_signals, trading_module, pair_dicts)
         return stats_module.analyze()
 

--- a/backtesting/strategy.py
+++ b/backtesting/strategy.py
@@ -41,6 +41,7 @@ class Strategy(abc.ABC):
         """
         return
 
+    @abc.abstractmethod
     def buy_signal(self, dataframe: DataFrame) -> DataFrame:
         """
         :param dataframe: Dataframe filled with indicators from generate_indicators
@@ -50,6 +51,7 @@ class Strategy(abc.ABC):
         """
         return
 
+    @abc.abstractmethod
     def sell_signal(self, dataframe: DataFrame) -> DataFrame:
         """
         :param dataframe: Dataframe filled with indicators from generate_indicators

--- a/backtesting/strategy.py
+++ b/backtesting/strategy.py
@@ -11,6 +11,7 @@ from modules.public.trading_stats import TradingStats
 #
 # © 2021 DemaTrading.ai
 # ======================================================================
+from modules.stats.trade import Trade
 from utils.utils import parse_timeframe
 
 """
@@ -73,6 +74,18 @@ class Strategy(abc.ABC):
         :rtype: DataFrame
         """
         return
+
+    def buy_cooldown(self, last_trade: Trade) -> int:
+        """
+        Override this method if you want to add a buy cooldown when a trade is closed. This means that
+        for the pair of the closed trade, a new trade cannot be opened for x time-steps.
+
+        :param last_trade: The last trade that was closed
+        :type last_trade: Trade
+        :return: the amount of time-steps in which a new trade for the current pair may not be opened
+        :rtype: int
+        """
+        return 0
 
     def join_additional_data(self, dataframe, additional_pair, original_timeframe, timeframe_additional, ffill=True):
         """

--- a/modules/algo/backtesting.py
+++ b/modules/algo/backtesting.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from backtesting.strategy import Strategy
 from modules.public.pairs_data import PairsData
 from modules.setup.config import ConfigModule
-from cli.print_utils import print_info, print_warning, print_error
+from cli.print_utils import print_info, print_error
 from modules.setup.config.validations import validate_dynamic_stoploss
 
 
@@ -15,9 +15,6 @@ from modules.setup.config.validations import validate_dynamic_stoploss
 #
 # © 2021 DemaTrading.ai
 # ======================================================================
-#
-# These constants are used for displaying and
-# emphasizing in commandline backtestresults
 
 
 class BackTesting:
@@ -66,11 +63,14 @@ class BackTesting:
             indicators = self.strategy.sell_signal(indicators)
             indicators = indicators.append(df.loc[df["close"].isnull()]).sort_index()
             self.df[pair] = indicators.copy()
+
             if stoploss_type == "dynamic":
                 stoploss = self.strategy.stoploss(indicators)
                 validate_dynamic_stoploss(stoploss)
                 indicators['stoploss'] = stoploss['stoploss']
+
             data_dict[pair] = indicators.to_dict('index')
+
             if not self.df[pair][['open', 'high', 'low', 'close', 'volume', 'pair']].equals(
                     df[['open', 'high', 'low', 'close', 'volume', 'pair']]
             ):

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -41,6 +41,7 @@ class ConfigModule(object):
         self.exposure_per_trade = None
         self.stoploss_type = None
         self.stoploss = None
+        self.roi = None
         self.fee = None
         self.strategy_definition = None
         self.strategy_name = None

--- a/modules/stats/tradingmodule.py
+++ b/modules/stats/tradingmodule.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Optional
 
 # Files
+from backtesting.strategy import Strategy
 from cli.print_utils import print_info, print_warning
 from modules.stats.trade import SellReason, Trade
 from modules.stats.tradingmodule_config import TradingModuleConfig
@@ -17,8 +18,9 @@ from modules.stats.tradingmodule_config import TradingModuleConfig
 
 class TradingModule:
 
-    def __init__(self, config: TradingModuleConfig):
+    def __init__(self, config: TradingModuleConfig, strategy: Strategy):
         self.config = config
+        self.strategy = strategy
         self.budget = float(self.config.starting_capital)
         self.realised_profit = self.budget
 
@@ -26,7 +28,8 @@ class TradingModule:
         self.exposure_per_trade = float(self.config.exposure_per_trade)
         self.amount_of_pairs = len(self.config.pairs)
         if self.amount_of_pairs < self.max_open_trades:
-            print_warning("max_open_trades exceeds amount of pairs in whitelist. max_open_trades will be limited to the amount of pairs in whitelist.")
+            print_warning("max_open_trades exceeds amount of pairs in whitelist. max_open_trades will be limited to "
+                          "the amount of pairs in whitelist.")
 
         self.fee = config.fee / 100
         self.sl_type = config.stoploss_type
@@ -42,6 +45,7 @@ class TradingModule:
         self.highest_total_capital_open_trades = {}
         self.total_fee_paid = 0
         self.rejected_buy_signal = 0
+        self.buy_cooldown = {pair: 0 for pair in self.config.pairs}
 
     def tick(self, ohlcv: dict, data_dict: dict) -> None:
         trade = self.find_open_trade(ohlcv['pair'])
@@ -54,6 +58,9 @@ class TradingModule:
         self.update_capital_per_timestamp(ohlcv)
 
     def no_trade_tick(self, ohlcv: dict, data_dict: dict) -> None:
+        if self.buy_cooldown[ohlcv['pair']] > 0:
+            self.buy_cooldown[ohlcv['pair']] -= 1
+            return
         if ohlcv['buy'] == 1:
             self.open_trade(ohlcv, data_dict)
 
@@ -93,6 +100,8 @@ class TradingModule:
         self.open_trades.remove(trade)
         self.closed_trades.append(trade)
         self.update_realised_profit(trade)
+
+        self.buy_cooldown[ohlcv['pair']] = self.strategy.buy_cooldown(trade)
 
     def open_trade(self, ohlcv: dict, data_dict: dict) -> None:
 

--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -5,7 +5,6 @@ from backtesting.strategy import Strategy
 
 # Optional Imports
 from modules.setup.config import qtpylib_methods as qtpylib
-from modules.stats.trade import Trade, SellReason
 
 
 class MyStrategy(Strategy):

--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -5,6 +5,7 @@ from backtesting.strategy import Strategy
 
 # Optional Imports
 from modules.setup.config import qtpylib_methods as qtpylib
+from modules.stats.trade import Trade
 
 
 class MyStrategy(Strategy):
@@ -70,3 +71,15 @@ class MyStrategy(Strategy):
         # END STRATEGY
 
         return dataframe
+
+    def buy_cooldown(self, last_trade: Trade) -> int:
+        """
+        Override this method if you want to add a buy cooldown when a trade is closed. This means that
+        for the pair of the closed trade, a new trade cannot be opened for x time-steps.
+
+        :param last_trade: The last trade that was closed
+        :type last_trade: Trade
+        :return: the amount of time-steps in which a new trade for the current pair may not be opened
+        :rtype: int
+        """
+        return 5

--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -46,7 +46,7 @@ class MyStrategy(Strategy):
                 (dataframe['ema5'] < dataframe['ema21']) &
                 (dataframe['volume'] > 0)
             ),
-            'buy'] = 1
+            'buy'] = 0
 
         # END STRATEGY
 

--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -5,7 +5,7 @@ from backtesting.strategy import Strategy
 
 # Optional Imports
 from modules.setup.config import qtpylib_methods as qtpylib
-from modules.stats.trade import Trade
+from modules.stats.trade import Trade, SellReason
 
 
 class MyStrategy(Strategy):
@@ -71,15 +71,3 @@ class MyStrategy(Strategy):
         # END STRATEGY
 
         return dataframe
-
-    def buy_cooldown(self, last_trade: Trade) -> int:
-        """
-        Override this method if you want to add a buy cooldown when a trade is closed. This means that
-        for the pair of the closed trade, a new trade cannot be opened for x time-steps.
-
-        :param last_trade: The last trade that was closed
-        :type last_trade: Trade
-        :return: the amount of time-steps in which a new trade for the current pair may not be opened
-        :rtype: int
-        """
-        return 5

--- a/resources/setup/strategies/my_strategy.py
+++ b/resources/setup/strategies/my_strategy.py
@@ -45,7 +45,7 @@ class MyStrategy(Strategy):
                 (dataframe['ema5'] < dataframe['ema21']) &
                 (dataframe['volume'] > 0)
             ),
-            'buy'] = 0
+            'buy'] = 1
 
         # END STRATEGY
 

--- a/resources/setup/strategies/my_strategy_advanced.py
+++ b/resources/setup/strategies/my_strategy_advanced.py
@@ -6,6 +6,7 @@ from backtesting.strategy import Strategy
 # Optional Imports
 import numpy as np
 from modules.setup.config import qtpylib_methods as qtpylib
+from modules.stats.trade import Trade, SellReason
 
 
 class MyStrategyAdvanced(Strategy):
@@ -164,3 +165,22 @@ class MyStrategyAdvanced(Strategy):
         # END STRATEGY
 
         return dataframe
+
+    def buy_cooldown(self, last_trade: Trade) -> int:
+        """
+        Override this method if you want to add a buy cooldown when a trade is closed. This means that
+        for the pair of the closed trade, a new trade cannot be opened for x time-steps.
+
+        :param last_trade: The last trade that was closed
+        :type last_trade: Trade
+        :return: the amount of time-steps in which a new trade for the current pair may not be opened
+        :rtype: int
+        """
+        cooldown = 0
+        if last_trade.sell_reason == SellReason.STOPLOSS:
+            cooldown = 10
+        elif last_trade.sell_reason == SellReason.SELL_SIGNAL:
+            cooldown = 5
+        elif last_trade.sell_reason == SellReason.ROI:
+            cooldown = 1
+        return cooldown

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+from pandas import DataFrame
 
 from backtesting.strategy import Strategy
 from modules.stats.stats import StatsModule
@@ -82,11 +83,19 @@ class StatsFixture:
 
 
 class TestStrategy(Strategy):
-    pass
+    # Empty strategy used for testing purposes
+    def generate_indicators(self, dataframe: DataFrame, additional_pairs=None) -> DataFrame:
+        return dataframe
+
+    def buy_signal(self, dataframe: DataFrame) -> DataFrame:
+        return dataframe
+
+    def sell_signal(self, dataframe: DataFrame) -> DataFrame:
+        return dataframe
 
 
-class CooldownStrategy(Strategy):
-
+class CooldownStrategy(TestStrategy):
+    # Addition to the testing strategy to test cooldowns
     def buy_cooldown(self, last_trade: Trade) -> int:
         cooldown = 0
         if last_trade.sell_reason == SellReason.STOPLOSS:

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -82,11 +82,11 @@ class StatsFixture:
         return StatsModule(self.stats_config, self.frame_with_signals, trading_module, pair_df)
 
 
-class TestStrategy(MyStrategy):
+class TestStrategy(Strategy):
     pass
 
 
-class CooldownStrategy(MyStrategy):
+class CooldownStrategy(Strategy):
 
     def buy_cooldown(self, last_trade: Trade) -> int:
         cooldown = 0

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -2,6 +2,7 @@ import os
 
 import pandas as pd
 
+from backtesting.strategy import Strategy
 from modules.stats.stats import StatsModule
 from modules.stats.stats_config import StatsConfig
 from modules.stats.tradingmodule import TradingModule
@@ -70,18 +71,22 @@ class StatsFixture:
         pair_df = {k: pd.DataFrame.from_dict(v, orient='index', columns=OHLCV_INDICATORS) for k, v in
                    self.frame_with_signals.items()}
 
-        trading_module = TradingModule(self.trading_module_config, MyStrategy())
+        trading_module = TradingModule(self.trading_module_config, TestStrategy())
         return StatsModule(self.stats_config, self.frame_with_signals, trading_module, pair_df)
 
-    def create_with_test_strategy(self):
+    def create_with_strategy(self, strategy: Strategy):
         pair_df = {k: pd.DataFrame.from_dict(v, orient='index', columns=OHLCV_INDICATORS) for k, v in
                    self.frame_with_signals.items()}
 
-        trading_module = TradingModule(self.trading_module_config, TestStrategy())
+        trading_module = TradingModule(self.trading_module_config, strategy)
         return StatsModule(self.stats_config, self.frame_with_signals, trading_module, pair_df)
 
 
 class TestStrategy(MyStrategy):
+    pass
+
+
+class CooldownStrategy(MyStrategy):
 
     def buy_cooldown(self, last_trade: Trade) -> int:
         cooldown = 0

--- a/test/stats/stats_test_utils.py
+++ b/test/stats/stats_test_utils.py
@@ -7,7 +7,6 @@ from modules.stats.stats import StatsModule
 from modules.stats.stats_config import StatsConfig
 from modules.stats.tradingmodule import TradingModule
 from modules.stats.tradingmodule_config import TradingModuleConfig
-from resources.setup.strategies.my_strategy import MyStrategy
 from test.utils.signal_frame import MockPairFrame
 from utils.utils import get_ohlcv_indicators
 from modules.stats.trade import Trade, SellReason

--- a/test/stats/test_main_results.py
+++ b/test/stats/test_main_results.py
@@ -1,7 +1,7 @@
 import math
 from datetime import timedelta
 
-from test.stats.stats_test_utils import StatsFixture
+from test.stats.stats_test_utils import StatsFixture, CooldownStrategy
 from test.utils.signal_frame import ONE_MIL, THIRTY_MIN, EIGHT_HOURS, SIX_HOURS, TWELVE_HOURS
 
 
@@ -768,7 +768,7 @@ def test_cooldown_sell_signal():
     fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
 
     # Act
-    stats = fixture.create_with_test_strategy().analyze()
+    stats = fixture.create_with_strategy(CooldownStrategy()).analyze()
 
     # Assert
     assert stats.main_results.n_trades == 1
@@ -789,7 +789,7 @@ def test_cooldown_stoploss():
     fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
 
     # Act
-    stats = fixture.create_with_test_strategy().analyze()
+    stats = fixture.create_with_strategy(CooldownStrategy()).analyze()
 
     # Assert
     assert stats.main_results.n_trades == 2
@@ -813,7 +813,7 @@ def test_cooldown_roi():
     fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
 
     # Act
-    stats = fixture.create_with_test_strategy().analyze()
+    stats = fixture.create_with_strategy(CooldownStrategy()).analyze()
 
     # Assert
     assert stats.main_results.n_trades == 3

--- a/test/stats/test_main_results.py
+++ b/test/stats/test_main_results.py
@@ -53,7 +53,7 @@ def test_roi_reached_multiple_times():
 
 
 def test_roi_set_not_reached():
-    """Given 'multiple roi reached and multiple buys', 'capital' should 'reflect expected value'"""
+    """Given 'multiple roi not reached and multiple buys', 'capital' should 'reflect expected value'"""
     # Arrange
     fixture = StatsFixture(['COIN'])
 
@@ -755,3 +755,65 @@ def test_risk_reward_ratio_one_losing_trade():
     # Assert
     assert stats.main_results.risk_reward_ratio == 0
     assert isinstance(stats.main_results.risk_reward_ratio, float)
+
+
+def test_cooldown_sell_signal():
+    # Tests the cooldown function - with multiple buy and sell signals, on which the consecutive ones fall in
+    # the cooldown period.
+
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    # Win/Loss/Open
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
+    # Act
+    stats = fixture.create_with_test_strategy().analyze()
+
+    # Assert
+    assert stats.main_results.n_trades == 1
+
+
+def test_cooldown_stoploss():
+    # Tests the cooldown function - when stoploss is hit
+
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.trading_module_config.stoploss = -25
+    fixture.stats_config.stoploss = -25
+
+    # Win/Loss/Open
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+
+    # Act
+    stats = fixture.create_with_test_strategy().analyze()
+
+    # Assert
+    assert stats.main_results.n_trades == 2
+
+
+def test_cooldown_roi():
+    # Tests the cooldown function - when roi is hit
+
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    fixture.trading_module_config.roi = {
+        "0": 25
+    }
+
+    # Win/Loss/Open
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_50_one_trade()
+
+    # Act
+    stats = fixture.create_with_test_strategy().analyze()
+
+    # Assert
+    assert stats.main_results.n_trades == 3


### PR DESCRIPTION
# Results of merging this
Adds a cooldown function in the strategy file that can be used to implement custom cooldowns on separate trade sell reasons.