### PR TITLE
[Feat] Better trade overview

### DIFF
--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -76,7 +76,6 @@ def show_mainresults(self: MainResults, currency_symbol: str):
 
     # Trade info table
     trade_info_table = create_trade_info_table(self,
-                                               currency_symbol,
                                                justification
                                                )
 
@@ -90,7 +89,7 @@ def show_mainresults(self: MainResults, currency_symbol: str):
     console_color.print(table_grid)
 
 
-def create_trade_info_table(self: MainResults, currency_symbol, justification) -> Table:
+def create_trade_info_table(self: MainResults, justification) -> Table:
     avg_trade_duration = format_time_difference(self.avg_trade_duration)
     longest_trade_duration = format_time_difference(self.longest_trade_duration)
     shortest_trade_duration = format_time_difference(self.shortest_trade_duration)
@@ -217,7 +216,12 @@ class CoinInsights:
     roi: int
     stoploss: int
     sell_signal: int
-    trade_rankings: dict
+    best_trade_ratio: float
+    worst_trade_ratio: float
+    median_trade_ratio: float
+    best_trade_currency: float
+    worst_trade_currency: float
+    median_trade_currency: float
 
     @staticmethod
     def show(instances: typing.List['CoinInsights'], currency_symbol: str):
@@ -239,6 +243,12 @@ class CoinInsights:
                                            colorize(round(c.cum_profit_percentage, 2), 0),
                                            colorize(round(c.total_profit_percentage, 2), 0),
                                            colorize(round(c.profit, 2), 0),
+                                           f"{colorize(round((c.best_trade_ratio - 1) * 100, 2), 0)} / "
+                                           f"{colorize(round((c.worst_trade_ratio - 1) * 100, 2), 0)} / "
+                                           f"{colorize(round((c.median_trade_ratio - 1) * 100, 2), 0)}",
+                                           f"{colorize(round(c.best_trade_currency, 2), 0)} / "
+                                           f"{colorize(round(c.worst_trade_currency, 2), 0)} / "
+                                           f"{colorize(round(c.median_trade_currency, 2), 0)}"
                                            )
 
             coin_metrics_table.add_row(c.pair,
@@ -251,7 +261,9 @@ class CoinInsights:
                                        )
 
             coin_signal_table.add_row(c.pair,
-                                      f"{c.n_trades} ([bright_green]{c.n_wins}[/bright_green]/[bright_red]{c.n_losses}[/bright_red])",
+                                      f"{c.n_trades} ([bright_green]"
+                                      f"{c.n_wins}[/bright_green]/[bright_red]"
+                                      f"{c.n_losses}[/bright_red])",
                                       str(shortest_trade_duration),
                                       str(avg_trade_duration),
                                       str(longest_trade_duration),

--- a/modules/output/results.py
+++ b/modules/output/results.py
@@ -1,7 +1,6 @@
 # Libraries
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-import typing
 
 from rich.console import JustifyMethod
 from rich.padding import Padding
@@ -224,10 +223,12 @@ class CoinInsights:
     median_trade_currency: float
 
     @staticmethod
-    def show(instances: typing.List['CoinInsights'], currency_symbol: str):
+    def show(instances: ['CoinInsights'], currency_symbol: str):
         justification: JustifyMethod = "center"
 
         coin_performance_table = CoinInsights.create_coin_performance_table(justification, currency_symbol)
+
+        trade_perf_per_coin_table = CoinInsights.create_trade_perf_per_coin_table(justification, currency_symbol)
 
         coin_metrics_table = CoinInsights.create_coin_metrics_table(justification)
 
@@ -242,14 +243,17 @@ class CoinInsights:
                                            colorize(round(c.avg_profit_percentage, 2), 0),
                                            colorize(round(c.cum_profit_percentage, 2), 0),
                                            colorize(round(c.total_profit_percentage, 2), 0),
-                                           colorize(round(c.profit, 2), 0),
-                                           f"{colorize(round((c.best_trade_ratio - 1) * 100, 2), 0)} / "
-                                           f"{colorize(round((c.worst_trade_ratio - 1) * 100, 2), 0)} / "
-                                           f"{colorize(round((c.median_trade_ratio - 1) * 100, 2), 0)}",
-                                           f"{colorize(round(c.best_trade_currency, 2), 0)} / "
-                                           f"{colorize(round(c.worst_trade_currency, 2), 0)} / "
-                                           f"{colorize(round(c.median_trade_currency, 2), 0)}"
+                                           colorize(round(c.profit, 2), 0)
                                            )
+
+            trade_perf_per_coin_table.add_row(c.pair,
+                                              f"{colorize(round((c.best_trade_ratio - 1) * 100, 2), 0)} / "
+                                              f"{colorize(round((c.median_trade_ratio - 1) * 100, 2), 0)} / "
+                                              f"{colorize(round((c.worst_trade_ratio - 1) * 100, 2), 0)}",
+                                              f"{colorize(round(c.best_trade_currency, 2), 0)} / "
+                                              f"{colorize(round(c.median_trade_currency, 2), 0)} / "
+                                              f"{colorize(round(c.worst_trade_currency, 2), 0)}"
+                                              )
 
             coin_metrics_table.add_row(c.pair,
                                        colorize(round(c.market_change, 2), 0),
@@ -275,25 +279,37 @@ class CoinInsights:
         table_grid = Table(box=box.SIMPLE)
         table_grid.add_column(":moneybag: COIN INSIGHTS :moneybag:")
         table_grid.add_row(coin_performance_table)
+        table_grid.add_row(trade_perf_per_coin_table)
         table_grid.add_row(coin_metrics_table)
         table_grid.add_row(coin_signal_table)
         console_color.print(table_grid)
 
     @staticmethod
-    def create_coin_performance_table(justification, currency_symbol: str) -> Table:
+    def create_coin_performance_table(justification: JustifyMethod, currency_symbol: str) -> Table:
         coin_performance_table = Table(title="Coin Performance\n(All columns indicate returns)",
-                                       box=box.ROUNDED)
+                                       box=box.ROUNDED,
+                                       width=100)
         coin_performance_table.add_column("Pair", justify=justification)
         coin_performance_table.add_column("Average (%)", justify=justification)
         coin_performance_table.add_column("Cumulative (%)", justify=justification)
         coin_performance_table.add_column("Total (%)", justify=justification)
         coin_performance_table.add_column(f"Actual ({currency_symbol})", justify=justification)
-        coin_performance_table.add_column("Percentage-based", justify=justification)
-        coin_performance_table.add_column("Currency-based", justify=justification)
         return coin_performance_table
 
     @staticmethod
-    def create_coin_metrics_table(justification) -> Table:
+    def create_trade_perf_per_coin_table(justification: JustifyMethod, currency_symbol: str) -> Table:
+        trade_perf_per_coin_table = Table(title="Trade Performance per Coin",
+                                          box=box.ROUNDED,
+                                          width=100)
+        trade_perf_per_coin_table.add_column("Pair", justify=justification)
+        trade_perf_per_coin_table.add_column("Relative trade ranking (%)\nBest / median / worst", justify=justification)
+        trade_perf_per_coin_table.add_column(f"Absolute trade ranking ({currency_symbol})\nBest / median / worst",
+                                             justify=justification)
+
+        return trade_perf_per_coin_table
+
+    @staticmethod
+    def create_coin_metrics_table(justification: JustifyMethod) -> Table:
         coin_metrics_table = Table(title="Coin Metrics", box=box.ROUNDED, width=100)
         coin_metrics_table.add_column("Pair", justify=justification)
         coin_metrics_table.add_column("Market change (%)", justify=justification)
@@ -308,7 +324,7 @@ class CoinInsights:
         return coin_metrics_table
 
     @staticmethod
-    def create_coin_signals_table(justification) -> Table:
+    def create_coin_signals_table(justification: JustifyMethod) -> Table:
         coin_signal_table = Table(title="Coin Signals", box=box.ROUNDED, width=100)
         coin_signal_table.add_column("Pair", justify=justification)
         coin_signal_table.add_column("Trades (W/L)", justify=justification)
@@ -330,7 +346,7 @@ class LeftOpenTradeResult:
     opened_at: datetime
 
     @staticmethod
-    def show(instances: typing.List['LeftOpenTradeResult'], currency_symbol):
+    def show(instances: ['LeftOpenTradeResult'], currency_symbol):
         justification: JustifyMethod = "center"
 
         left_open_trades_table = LeftOpenTradeResult.create_left_open_trades_table(justification, currency_symbol)
@@ -349,7 +365,7 @@ class LeftOpenTradeResult:
         console_color.print(table_grid)
 
     @staticmethod
-    def create_left_open_trades_table(justification, currency_symbol) -> Table:
+    def create_left_open_trades_table(justification: JustifyMethod, currency_symbol) -> Table:
         left_open_trades_table = Table(title="Left open trades", box=box.ROUNDED, width=100)
         left_open_trades_table.add_column("Pair", justify=justification)
         left_open_trades_table.add_column("Cur. profit (%)", justify=justification)

--- a/modules/public/trading_stats.py
+++ b/modules/public/trading_stats.py
@@ -28,14 +28,7 @@ class MainResults:
     n_trades_with_loss: int
     n_consecutive_losses: int
     max_realised_drawdown: float
-    worst_trade_profit_percentage: float
-    worst_trade_currency_amount: float
-    worst_trade_pair: str
-    best_trade_profit_percentage: float
-    best_trade_currency_amount: float
-    best_trade_pair: str
     risk_reward_ratio: float
-    median_trade_profit: float
     avg_trade_duration: timedelta
     longest_trade_duration: timedelta
     shortest_trade_duration: timedelta

--- a/modules/stats/metrics/trades.py
+++ b/modules/stats/metrics/trades.py
@@ -4,7 +4,7 @@ from typing import Optional
 from modules.stats.trade import Trade
 
 
-def med(trades_return: list[float, ...], default=None) -> Optional[float]:
+def med(trades_return: [float, ...], default=None) -> Optional[float]:
     """Finds the median in a list of trade returns"""
 
     trades_return = sorted(trades_return)
@@ -71,8 +71,9 @@ def calculate_trade_durations(closed_trades: [Trade]):
 
 
 def compute_risk_reward_ratio(closed_trades: [Trade]) -> float:
+
     if len(closed_trades) == 0:
-        return 0.0
+        return 0
 
     winning_trades = []
     losing_trades = []

--- a/modules/stats/metrics/trades.py
+++ b/modules/stats/metrics/trades.py
@@ -48,7 +48,7 @@ def compute_median_trade_profit(closed_trades: [Trade]) -> float:
     if len(closed_trades) == 0:
         return 0.0
 
-    all_trade_profit = [trade.profit_dollar for trade in closed_trades]
+    all_trade_profit = [trade.profit_currency for trade in closed_trades]
 
     median_trade_profit = median(all_trade_profit)
 
@@ -65,12 +65,12 @@ def compute_risk_reward_ratio(closed_trades: [Trade]) -> float:
 
     for trade in closed_trades:  # Ignore trades with a profit of 0
 
-        if trade.profit_dollar > 0:
-            winning_trades.append(trade.profit_dollar)
+        if trade.profit_currency > 0:
+            winning_trades.append(trade.profit_currency)
             continue
 
-        if trade.profit_dollar < 0:
-            losing_trades.append(trade.profit_dollar)
+        if trade.profit_currency < 0:
+            losing_trades.append(trade.profit_currency)
 
     total_gain = sum(winning_trades)
     total_loss = sum(losing_trades)

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -54,12 +54,13 @@ class StatsModule:
 
         market_change = get_market_change(self.df, pairs, self.frame_with_signals)
         market_drawdown = get_market_drawdown(pairs, self.frame_with_signals)
-        return self.generate_backtesting_result(market_change, market_drawdown)
+        return self.generate_backtesting_result(market_change, market_drawdown, pairs)
 
-    def generate_backtesting_result(self, market_change: dict, market_drawdown: dict) -> TradingStats:
+    def generate_backtesting_result(self, market_change: dict, market_drawdown: dict, pairs: list) -> TradingStats:
         coin_results, market_change_weekly = self.generate_coin_results(self.trading_module.closed_trades,
                                                                         market_change,
-                                                                        market_drawdown)
+                                                                        market_drawdown,
+                                                                        pairs)
         open_trade_results = self.get_left_open_trades_results(self.trading_module.open_trades)
 
         main_results = self.generate_main_results(
@@ -170,9 +171,10 @@ class StatsModule:
                            risk_reward_ratio=risk_reward_ratio
                            )
 
-    def generate_coin_results(self, closed_trades: [Trade], market_change: dict, market_drawdown: dict) -> [list, dict]:
+    def generate_coin_results(self, closed_trades: [Trade], market_change: dict, market_drawdown: dict, pairs: list) \
+            -> [list, dict]:
         stats, market_change_weekly = self.calculate_statistics_per_coin(closed_trades)
-        trade_rankings = compute_trade_rankings(closed_trades)
+        trade_rankings = compute_trade_rankings(closed_trades, pairs)
         new_stats = []
 
         for coin in stats:
@@ -203,7 +205,12 @@ class StatsModule:
                                         roi=stats[coin]['sell_reasons'][SellReason.ROI],
                                         stoploss=stats[coin]['sell_reasons'][SellReason.STOPLOSS],
                                         sell_signal=stats[coin]['sell_reasons'][SellReason.SELL_SIGNAL],
-                                        trade_rankings=trade_rankings)
+                                        best_trade_ratio=trade_rankings[coin]['ratio']['best'],
+                                        worst_trade_ratio=trade_rankings[coin]['ratio']['worst'],
+                                        median_trade_ratio=trade_rankings[coin]['ratio']['median'],
+                                        best_trade_currency=trade_rankings[coin]['currency']['best'],
+                                        worst_trade_currency=trade_rankings[coin]['currency']['worst'],
+                                        median_trade_currency=trade_rankings[coin]['currency']['median'])
             new_stats.append(coin_insight)
 
         return new_stats, market_change_weekly

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -14,9 +14,8 @@ from modules.stats.drawdown.for_portfolio import get_max_seen_drawdown_for_portf
 from modules.stats.ratios.for_portfolio import get_sharpe_sortino_ratios
 from modules.stats.drawdown.per_trade import get_max_seen_drawdown_per_trade
 from modules.stats.metrics.market_change import get_market_change, get_market_drawdown
-from modules.stats.metrics.trades import calculate_best_worst_trade, get_number_of_losing_trades, \
-    get_number_of_consecutive_losing_trades, calculate_trade_durations, compute_median_trade_profit, \
-    compute_risk_reward_ratio
+from modules.stats.metrics.trades import compute_trade_rankings, get_number_of_losing_trades, \
+    get_number_of_consecutive_losing_trades, calculate_trade_durations, compute_risk_reward_ratio
 from modules.stats.metrics.winning_weeks import get_winning_weeks_per_coin, \
     get_winning_weeks_for_portfolio, get_profitable_weeks_for_portfolio, get_profitable_weeks_per_coin
 from modules.stats.stats_config import StatsConfig
@@ -61,7 +60,6 @@ class StatsModule:
         coin_results, market_change_weekly = self.generate_coin_results(self.trading_module.closed_trades,
                                                                         market_change,
                                                                         market_drawdown)
-        best_trade, worst_trade = calculate_best_worst_trade(self.trading_module.closed_trades)
         open_trade_results = self.get_left_open_trades_results(self.trading_module.open_trades)
 
         main_results = self.generate_main_results(
@@ -70,8 +68,6 @@ class StatsModule:
             self.trading_module.budget,
             market_change,
             market_drawdown,
-            best_trade,
-            worst_trade,
             market_change_weekly)
         self.calculate_statistics_for_plots(self.trading_module.closed_trades, self.trading_module.open_trades)
 
@@ -88,8 +84,7 @@ class StatsModule:
         )
 
     def generate_main_results(self, open_trades: [Trade], closed_trades: [Trade], budget: float,
-                              market_change: dict, market_drawdown: dict, best_trade, worst_trade,
-                              market_change_weekly: dict) -> MainResults:
+                              market_change: dict, market_drawdown: dict, market_change_weekly: dict) -> MainResults:
         # Get total budget and calculate overall profit
         budget += calculate_worth_of_open_trades(open_trades)
         overall_profit_percentage = ((budget - self.config.starting_capital) / self.config.starting_capital) * 100
@@ -120,23 +115,7 @@ class StatsModule:
         nr_losing_trades = get_number_of_losing_trades(closed_trades)
         nr_consecutive_losing_trades = get_number_of_consecutive_losing_trades(closed_trades)
 
-        best_trade_profit_percentage = 0
-        best_trade_currency_amount = 0
-        best_trade_pair = ""
-        worst_trade_profit_percentage = 0
-        worst_trade_currency_amount = 0
-        worst_trade_pair = ""
-        risk_reward_ratio = 0
-        if best_trade:
-            best_trade_profit_percentage = (best_trade.profit_ratio - 1) * 100
-            worst_trade_profit_percentage = (worst_trade.profit_ratio - 1) * 100
-            best_trade_currency_amount = best_trade.profit_currency
-            worst_trade_currency_amount = worst_trade.profit_currency
-            best_trade_pair = best_trade.pair
-            worst_trade_pair = worst_trade.pair
-            risk_reward_ratio = compute_risk_reward_ratio(closed_trades)
-
-        median_trade_profit = compute_median_trade_profit(closed_trades)
+        risk_reward_ratio = compute_risk_reward_ratio(closed_trades)
 
         avg_trade_duration, longest_trade_duration, shortest_trade_duration = \
             calculate_trade_durations(closed_trades)
@@ -166,12 +145,6 @@ class StatsModule:
                            n_trades_with_loss=nr_losing_trades,
                            n_consecutive_losses=nr_consecutive_losing_trades,
                            max_realised_drawdown=(max_realised_drawdown - 1) * 100,
-                           worst_trade_profit_percentage=worst_trade_profit_percentage,
-                           worst_trade_currency_amount=worst_trade_currency_amount,
-                           worst_trade_pair=worst_trade_pair,
-                           best_trade_profit_percentage=best_trade_profit_percentage,
-                           best_trade_currency_amount=best_trade_currency_amount,
-                           best_trade_pair=best_trade_pair,
                            avg_trade_duration=avg_trade_duration,
                            longest_trade_duration=longest_trade_duration,
                            shortest_trade_duration=shortest_trade_duration,
@@ -194,12 +167,12 @@ class StatsModule:
                            sharpe_3y=sharpe_3y,
                            sortino_90d=sortino_90d,
                            sortino_3y=sortino_3y,
-                           median_trade_profit=median_trade_profit,
                            risk_reward_ratio=risk_reward_ratio
                            )
 
     def generate_coin_results(self, closed_trades: [Trade], market_change: dict, market_drawdown: dict) -> [list, dict]:
         stats, market_change_weekly = self.calculate_statistics_per_coin(closed_trades)
+        trade_rankings = compute_trade_rankings(closed_trades)
         new_stats = []
 
         for coin in stats:
@@ -229,7 +202,8 @@ class StatsModule:
                                         shortest_trade_duration=stats[coin]['shortest_trade_duration'],
                                         roi=stats[coin]['sell_reasons'][SellReason.ROI],
                                         stoploss=stats[coin]['sell_reasons'][SellReason.STOPLOSS],
-                                        sell_signal=stats[coin]['sell_reasons'][SellReason.SELL_SIGNAL])
+                                        sell_signal=stats[coin]['sell_reasons'][SellReason.SELL_SIGNAL],
+                                        trade_rankings=trade_rankings)
             new_stats.append(coin_insight)
 
         return new_stats, market_change_weekly

--- a/modules/stats/stats.py
+++ b/modules/stats/stats.py
@@ -130,8 +130,8 @@ class StatsModule:
         if best_trade:
             best_trade_profit_percentage = (best_trade.profit_ratio - 1) * 100
             worst_trade_profit_percentage = (worst_trade.profit_ratio - 1) * 100
-            best_trade_currency_amount = best_trade.profit_dollar
-            worst_trade_currency_amount = worst_trade.profit_dollar
+            best_trade_currency_amount = best_trade.profit_currency
+            worst_trade_currency_amount = worst_trade.profit_currency
             best_trade_pair = best_trade.pair
             worst_trade_pair = worst_trade.pair
             risk_reward_ratio = compute_risk_reward_ratio(closed_trades)
@@ -316,7 +316,7 @@ class StatsModule:
                     per_coin_stats[key]['total_profit_ratio'] * trade.profit_ratio
 
                 # Update profit and amount of trades
-                per_coin_stats[key]['total_profit_amount'] += trade.profit_dollar
+                per_coin_stats[key]['total_profit_amount'] += trade.profit_currency
                 per_coin_stats[key]['amount_of_trades'] += 1
                 if trade.profit_ratio > 1:
                     per_coin_stats[key]['amount_of_winning_trades'] += 1
@@ -359,7 +359,7 @@ class StatsModule:
             )
             left_open_trade_results = LeftOpenTradeResult(pair=trade.pair,
                                                           curr_profit_percentage=(trade.profit_ratio - 1) * 100,
-                                                          curr_profit=trade.profit_dollar,
+                                                          curr_profit=trade.profit_currency,
                                                           max_seen_drawdown=(max_seen_drawdown - 1) * 100,
                                                           opened_at=trade.opened_at)
 

--- a/modules/stats/trade.py
+++ b/modules/stats/trade.py
@@ -44,7 +44,7 @@ class Trade:
         self.candle_low = None
         self.candle_open = None
         self.profit_ratio = None
-        self.profit_dollar = None
+        self.profit_currency = None
 
         # Calculations for trade worth
         self.max_seen_drawdown = 1.0  # ratio
@@ -84,7 +84,7 @@ class Trade:
         if update_capital:  # always triggers except when a trade is closed
             self.capital = self.currency_amount * self.current
         self.profit_ratio = self.capital / self.starting_amount
-        self.profit_dollar = self.capital - self.starting_amount
+        self.profit_currency = self.capital - self.starting_amount
 
     def configure_stoploss(self) -> None:
         if self.sl_type == 'standard':  # for backwards compatability - can be removed in the future

--- a/modules/stats/tradingmodule.py
+++ b/modules/stats/tradingmodule.py
@@ -7,6 +7,7 @@ from cli.print_utils import print_info, print_warning
 from modules.stats.trade import SellReason, Trade
 from modules.stats.tradingmodule_config import TradingModuleConfig
 
+
 # ======================================================================
 # TradingModule is responsible for tracking trades, calling strategy methods
 # and virtually opening / closing trades based on strategies' signal.
@@ -26,7 +27,8 @@ class TradingModule:
         self.exposure_per_trade = float(self.config.exposure_per_trade)
         self.amount_of_pairs = len(self.config.pairs)
         if self.amount_of_pairs < self.max_open_trades:
-            print_warning("max_open_trades exceeds amount of pairs in whitelist. max_open_trades will be limited to the amount of pairs in whitelist.")
+            print_warning(
+                "max_open_trades exceeds amount of pairs in whitelist. max_open_trades will be limited to the amount of pairs in whitelist.")
 
         self.fee = config.fee / 100
         self.sl_type = config.stoploss_type
@@ -109,7 +111,8 @@ class TradingModule:
             return
 
         # Define spend amount based on realised profit
-        spend_amount = ((1. / min(self.max_open_trades, self.amount_of_pairs)) * self.exposure_per_trade) * self.realised_profit
+        spend_amount = ((1. / min(self.max_open_trades, self.amount_of_pairs))
+                        * self.exposure_per_trade) * self.realised_profit
         if spend_amount > self.budget:
             spend_amount = self.budget
 
@@ -196,5 +199,5 @@ class TradingModule:
             self.budget_per_timestamp[ohlcv['time']] + self.total_capital_open_trades.get(ohlcv['time'], 0)
 
     def update_realised_profit(self, trade: Trade) -> None:
-        self.realised_profit += trade.profit_dollar
-        self.realised_profits_per_timestamp[int(datetime.timestamp(trade.closed_at)*1000)] = self.realised_profit
+        self.realised_profit += trade.profit_currency
+        self.realised_profits_per_timestamp[int(datetime.timestamp(trade.closed_at) * 1000)] = self.realised_profit

--- a/test/stats/test_coin_insights.py
+++ b/test/stats/test_coin_insights.py
@@ -23,7 +23,7 @@ def test_fee_equals_stoploss():
     assert math.isclose(stats.coin_results[0].total_profit_percentage, -1.99)
 
 
-def test_profit_worst_trade():
+def test_return_worst_trade():
     """Given only losing trades, 'worst trade' should be worst of all trades"""
     # Arrange
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
@@ -37,10 +37,10 @@ def test_profit_worst_trade():
 
     # Assert
     assert math.isclose(stats.coin_results[-1].total_profit_percentage, -75.4975)
-    assert math.isclose(stats.main_results.worst_trade_profit_percentage, -75.4975)
+    assert math.isclose(stats.coin_results[-1].worst_trade_ratio, 0.245025)
 
 
-def test_profit_best_trade():
+def test_return_best_trade():
     """Given only winning trades, 'best trade' should be best of all trades"""
     # Arrange
     fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
@@ -54,10 +54,33 @@ def test_profit_best_trade():
 
     # Assert
     assert math.isclose(stats.coin_results[-1].total_profit_percentage, 96.02)
-    assert math.isclose(stats.main_results.best_trade_profit_percentage, 96.02)
+    assert math.isclose(stats.coin_results[-1].best_trade_ratio, 1.9602)
 
 
-def test_profit_best_worst_trade_only_wins():
+def test_return_different_trades():
+    """Given three different trades, should return three different trades, one per metric"""
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE', 'COIN2/BASE', 'COIN3/BASE'])
+
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_50_one_trade()
+    fixture.frame_with_signals['COIN2/BASE'].test_scenario_up_50_one_trade()
+    fixture.frame_with_signals['COIN3/BASE'].test_scenario_up_100_one_trade()
+
+    # Act
+    stats = fixture.create().analyze()
+
+    sorted_trades = sorted(stats.coin_results, key=lambda coin: coin.total_profit_percentage, reverse=True)
+
+    # Assert
+    assert math.isclose(sorted_trades[0].best_trade_ratio, 1.9602)
+    assert math.isclose(sorted_trades[0].best_trade_currency, 32.006, abs_tol=0.001)
+    assert math.isclose(sorted_trades[1].median_trade_ratio, 1.47015, abs_tol=0.00001)
+    assert math.isclose(sorted_trades[1].median_trade_currency, 15.6717, abs_tol=0.0001)
+    assert math.isclose(sorted_trades[2].worst_trade_ratio, 0.49005)
+    assert math.isclose(sorted_trades[2].worst_trade_currency, -16.9983, abs_tol=0.0001)
+
+
+def test_return_best_worst_trade_only_wins():
     """Given only winning trades, 'worst trade' should be worst of all trades,
     and 'best trade' should be best of all trades"""
     # Arrange
@@ -70,13 +93,13 @@ def test_profit_best_worst_trade_only_wins():
     stats = fixture.create().analyze()
 
     # Assert
-    assert math.isclose(stats.main_results.best_trade_profit_percentage, 96.02)
+    assert math.isclose(stats.coin_results[1].best_trade_ratio, 1.9602)
     assert math.isclose(stats.coin_results[1].total_profit_percentage, 96.02)
-    assert math.isclose(stats.main_results.worst_trade_profit_percentage, 47.015)
+    assert math.isclose(stats.coin_results[0].worst_trade_ratio, 1.47015)
     assert math.isclose(stats.coin_results[0].total_profit_percentage, 47.015)
 
 
-def test_profit_best_worst_trade_only_losses():
+def test_return_best_worst_trade_only_losses():
     """Given only losing trades, 'worst trade' should be worst of all trades,
     and 'best trade' should be best of all trades"""
     # Arrange
@@ -89,13 +112,13 @@ def test_profit_best_worst_trade_only_losses():
     stats = fixture.create().analyze()
 
     # Assert
-    assert math.isclose(stats.main_results.best_trade_profit_percentage, -50.995)
+    assert math.isclose(stats.coin_results[0].best_trade_ratio, 0.49005, abs_tol=0.00001)
     assert math.isclose(stats.coin_results[0].total_profit_percentage, -50.995)
-    assert math.isclose(stats.main_results.worst_trade_profit_percentage, -75.4975)
+    assert math.isclose(stats.coin_results[1].worst_trade_ratio, 0.24502, abs_tol=0.00001)
     assert math.isclose(stats.coin_results[1].total_profit_percentage, -75.4975)
 
 
-def test_profit_no_trades():
+def test_return_no_trades():
     """Given no trades, profit should be zero"""
     # Arrange
     fixture = StatsFixture(['COIN/BASE'])
@@ -106,11 +129,49 @@ def test_profit_no_trades():
     stats = fixture.create().analyze()
 
     # Assert
-    assert math.isclose(stats.main_results.best_trade_profit_percentage, 0)
-    assert math.isclose(stats.main_results.worst_trade_profit_percentage, 0)
     assert math.isclose(stats.coin_results[0].total_profit_percentage, 0)
     assert math.isclose(stats.coin_results[0].cum_profit_percentage, 0)
     assert math.isclose(stats.coin_results[0].avg_profit_percentage, 0)
+
+
+def test_trade_performance_return():
+    # Checks the best, median, and worst trade profits, should return a float
+
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    # Win/Loss/Open
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
+
+    # Act
+    stats = fixture.create().analyze()
+
+    assert math.isclose(stats.coin_results[0].best_trade_ratio, 1.9602, abs_tol=0.0001)
+    assert math.isclose(stats.coin_results[0].best_trade_currency, 84.698, abs_tol=0.001)
+    assert math.isclose(stats.coin_results[0].worst_trade_ratio, 0.245025, abs_tol=0.00001)
+    assert math.isclose(stats.coin_results[0].worst_trade_currency, -130.541, abs_tol=0.001)
+    assert math.isclose(stats.coin_results[0].median_trade_ratio, 0.88209, abs_tol=0.00001)
+    assert math.isclose(stats.coin_results[0].median_trade_currency, -11.791, abs_tol=0.001)
+
+
+def test_trade_performance_return_no_trades():
+    # No trades, should return None
+
+    # Arrange
+    fixture = StatsFixture(['COIN/BASE'])
+
+    # Win/Loss/Open
+    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_no_trades()
+
+    # Act
+    stats = fixture.create().analyze()
+
+    assert stats.coin_results[0].best_trade_ratio is None
+    assert stats.coin_results[0].best_trade_currency is None
+    assert stats.coin_results[0].worst_trade_ratio is None
+    assert stats.coin_results[0].worst_trade_currency is None
+    assert stats.coin_results[0].median_trade_ratio is None
+    assert stats.coin_results[0].median_trade_currency is None
 
 
 def test_nr_of_trades_no_trades():

--- a/test/stats/test_main_results.py
+++ b/test/stats/test_main_results.py
@@ -539,44 +539,6 @@ def test_sharpe_sortino_ratios_no_sell():
     assert stats.main_results.sortino_90d is None
 
 
-def test_trade_profit():
-    # Checks the best, median, and worst trade profits, should return a float
-
-    # Arrange
-    fixture = StatsFixture(['COIN/BASE'])
-
-    # Win/Loss/Open
-    fixture.frame_with_signals['COIN/BASE'].test_scenario_down_10_up_100_down_75_three_trades()
-
-    # Act
-    stats = fixture.create().analyze()
-
-    assert math.isclose(stats.main_results.median_trade_profit, -11.791, abs_tol=0.001)
-    assert math.isclose(stats.main_results.best_trade_profit_percentage, 96.02, abs_tol=0.001)
-    assert math.isclose(stats.main_results.best_trade_currency_amount, 84.698, abs_tol=0.001)
-    assert math.isclose(stats.main_results.worst_trade_profit_percentage, -75.498, abs_tol=0.001)
-    assert math.isclose(stats.main_results.worst_trade_currency_amount, -130.541, abs_tol=0.001)
-
-
-def test_median_trade_profit_no_trades():
-    # No trades, should return 0.0
-
-    # Arrange
-    fixture = StatsFixture(['COIN/BASE'])
-
-    # Win/Loss/Open
-    fixture.frame_with_signals['COIN/BASE'].test_scenario_up_100_down_20_down_75_no_trades()
-
-    # Act
-    stats = fixture.create().analyze()
-
-    assert stats.main_results.median_trade_profit == 0.0
-    assert stats.main_results.best_trade_profit_percentage == 0.0
-    assert stats.main_results.best_trade_currency_amount == 0.0
-    assert stats.main_results.worst_trade_profit_percentage == 0.0
-    assert stats.main_results.worst_trade_currency_amount == 0.0
-
-
 def test_profitable_weeks_one_win():
     # One week, all days are positive - outcome should be one profitable week.
 


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Moves the best, median, and trade ratios from the trade info table to the coin performance table, giving the same info at a coin-level rather than global level. Also allows to view those rankings on a relative return base and absolute return base