### PR TITLE
[Fix] missing config file path

### DIFF
--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -114,9 +114,14 @@ def read_config(config_path: str) -> dict:
             data = configfile.read()
 
     except FileNotFoundError:
+        if config_path is None:
+            add_info = "Couldn't find a config file. Either use the flag '-c' with a path to the desired " \
+                       "config\n\tfile or name the file you wish to use 'config.json'."
+
+        else:
+            add_info = f"Couldn't find a file at {config_path}."
         ErrorOutput(sys.exc_info(),
-                    add_info=f"Couldn't find a config file. Either use the flag '-c' with a path to the desired "
-                             f"config\n\tfile or name the file you wish to use 'config.json'.",
+                    add_info=add_info,
                     stop=True).print_error()
 
     except Exception as e:

--- a/modules/setup/config/__init__.py
+++ b/modules/setup/config/__init__.py
@@ -115,9 +115,8 @@ def read_config(config_path: str) -> dict:
 
     except FileNotFoundError:
         ErrorOutput(sys.exc_info(),
-                    add_info=f"No config file found at {config_path}. You might be trying to run the Engine from the "
-                             f"wrong directory. See our documentation\n\t(https://docs.dematrading.ai) for detailed "
-                             f"instructions on how to run the Engine.",
+                    add_info=f"Couldn't find a config file. Either use the flag '-c' with a path to the desired "
+                             f"config\n\tfile or name the file you wish to use 'config.json'.",
                     stop=True).print_error()
 
     except Exception as e:


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
If a config file couldn't be found, the error message was supposed to print the path it was looking for. This is fixed by giving a different message if the path is None (happens if the user doesn't use the '-c' flag to point to a specific config file).