### PR TITLE
[ENG-53] Asyncio DeprecationWarning

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def main():
 
 def run_engine(args):
     controller = MainController()
-    asyncio.get_event_loop().run_until_complete(controller.run(args))
+    asyncio.run(controller.run(args))
 
 
 def run_init(args):


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
On Python 3.10, asyncio would raise a DeprecationWarning. This has been fixed for 3.10 and 3.9.

Needs testing on other versions before merging.