### PR TITLE
[ENG-63] Prepend JIRA key to commit message automatically

### DIFF
--- a/.github/.git-template/prepare-commit-msg
+++ b/.github/.git-template/prepare-commit-msg
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Include any branches for which you wish to disable this script
+
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(main development release/stable)
+fi
+
+# Get the current branch name and check if it is excluded
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+
+# Trim it down to get the parts we're interested in
+
+TRIMMED=$(echo "$BRANCH_NAME" | sed -e 's:^\([^-]*-[^-]*\)-.*:\1:' -e \
+    'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/')
+
+# If it isn't excluded, prepend the trimmed branch identifier to the given message
+
+if [ -n "$BRANCH_NAME" ] &&  ! [[ $BRANCH_EXCLUDED -eq 1 ]]; then
+  sed -i.bak -e "1s/^/[$TRIMMED] /" "$1"
+fi

--- a/cli/print_utils.py
+++ b/cli/print_utils.py
@@ -1,5 +1,4 @@
 import os
-#
 from typing import Literal
 
 from rich.console import Console

--- a/cli/print_utils.py
+++ b/cli/print_utils.py
@@ -1,6 +1,7 @@
 import os
-
+#
 from typing import Literal
+
 from rich.console import Console
 
 


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Makes available as a template a bash script that prepends the JIRA key at the start of the branch name in all commit messages automatically.