### PR TITLE
[ENG-97] Add resources flag to executable

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ from cli.arg_parse import execute_for_args
 from cli.checks.engine_use_statistics import engine_statistics
 from cli.checks.latest_version import print_warning_if_version_outdated
 from cli.prepare_workspace import prepare_workspace
-from cli.print_utils import print_debug, is_verbosity, print_warning
+from cli.print_utils import print_debug, is_verbosity
 from main_controller import MainController
-from utils.utils import check_internet_connection
+from utils.utils import check_internet_connection, prepend_resource_dir
 
 # Hack, PyInstaller + rich on Windows in GitHub actions fails because it cannot find encoding of stdout, this sets
 # it on stdout if not set
@@ -27,9 +27,6 @@ RUNFOLDER = os.path.dirname(os.path.realpath(__file__))
 def main(online: bool):
     if online:
         print_warning_if_version_outdated()
-    else:
-        print_warning("You are not connected to the internet. Certain functionality (like downloading new candle data)"
-                      " will not be available.")
     execute_for_args({
         'init': run_init,
         'default': run_engine
@@ -41,6 +38,10 @@ def main(online: bool):
 def run_engine(args, online: bool):
     if online:
         engine_statistics(args.no_statistics)
+
+    if args.resources:
+        prepend_resource_dir(args)
+
     controller = MainController()
     asyncio.run(controller.run(args, online))
 

--- a/resources/specification.json
+++ b/resources/specification.json
@@ -165,5 +165,13 @@
     "cli": {
       "short": "nostats"
     }
+  },
+  {
+    "name": "resources",
+    "type": "string",
+    "default": "./",
+    "cli": {
+      "short": "r"
+    }
   }
 ]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,4 +1,5 @@
 # Libraries
+import argparse
 import os
 import re
 import sys
@@ -21,7 +22,7 @@ def get_project_root():
     return Path(__file__).parent.parent
 
 
-def get_ohlcv_indicators() -> [str]:
+def get_ohlcv_indicators() -> [str, ...]:
     """
     :return: list with ohlcv indicator names
     """
@@ -94,3 +95,11 @@ def check_internet_connection() -> bool:
 
     except (requests.ConnectionError, requests.Timeout):
         return False
+
+
+def prepend_resource_dir(args: argparse.Namespace) -> None:
+    if args.config:
+        args.config = args.resources + args.config
+
+    else:
+        args.config = args.resources + "config.json"


### PR DESCRIPTION
# What has been changed?
<!-- Provide an overview of the changes you made, and how you approached it.  -->
Adds the possibility of specifying the location of the directory containing the config and strats when running the engine as an executable. Allows for easier scripting and to run the engine from a different directory.